### PR TITLE
테스트 시 act()로 감싸라는 경고

### DIFF
--- a/frontend/src/tests/App.test.tsx
+++ b/frontend/src/tests/App.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { App, routerConfig } from 'App';
@@ -11,17 +11,17 @@ test('메뉴에 있는 페이지들 렌더링', async () => {
 
   expect(screen.getByText('MainPage')).toBeInTheDocument();
 
-  await user.click(screen.getByText(/login/i));
+  await waitFor(() => user.click(screen.getByText(/login/i)));
   expect(screen.getByText(/LoginPage/i)).toBeInTheDocument();
-  await user.click(screen.getByText(/On Boarding/i));
+  await waitFor(async () => user.click(screen.getByText(/On Boarding/i)));
   expect(screen.getByText(/OnBoardingPage/i)).toBeInTheDocument();
-  await user.click(screen.getByText(/game/i));
+  await waitFor(async () => user.click(screen.getByText(/game/i)));
   expect(screen.getByText(/GamePage/i)).toBeInTheDocument();
-  await user.click(screen.getByText(/channel/i));
+  await waitFor(async () => user.click(screen.getByText(/channel/i)));
   expect(screen.getByText(/ChannelPage/i)).toBeInTheDocument();
-  await user.click(screen.getByText(/profile/i));
+  await waitFor(async () => user.click(screen.getByText(/profile/i)));
   expect(screen.getByText(/ProfilePage/i)).toBeInTheDocument();
-  await user.click(screen.getByText(/setting/i));
+  await waitFor(async () => user.click(screen.getByText(/setting/i)));
   expect(screen.getByText(/SettingPage/i)).toBeInTheDocument();
 });
 

--- a/frontend/src/tests/Profile.test.tsx
+++ b/frontend/src/tests/Profile.test.tsx
@@ -28,7 +28,7 @@ describe('Router - ProfilePage', () => {
 
     render(<RouterProvider router={router} />);
 
-    await waitFor(() => screen.getByText('ProfilePage'));
+    await screen.findByText('ProfilePage');
     screen.getByTestId('1');
   });
 });


### PR DESCRIPTION
## 작업 내용

- 이벤트를 발생시키는 비동기 작업을 `waitFor()` 함수로 감싸서 경고 해결
- Profile 테스트에서 `getByText()` 함수를 `waitFor()`로 감쌌던 부분을 `findByText()`로 변경
- closes #87 
