### PR TITLE
최초 로그인하는 회원에게 보이는 온보딩 플로우 구현

### DIFF
--- a/frontend/src/components/atoms/CheckboxInput.tsx
+++ b/frontend/src/components/atoms/CheckboxInput.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+interface Props {
+  id: string;
+  checked: boolean;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function CheckboxInput({ id, checked, onChange }: Props) {
+  return (
+    <input type="checkbox" id={id} checked={checked} onChange={onChange} />
+  );
+}

--- a/frontend/src/components/molecule/CheckboxInputWithLabel.tsx
+++ b/frontend/src/components/molecule/CheckboxInputWithLabel.tsx
@@ -1,0 +1,29 @@
+import CheckboxInput from 'components/atoms/CheckboxInput';
+import Label from 'components/atoms/Label';
+
+interface Props {
+  id: string;
+  label: string;
+  checked?: boolean;
+  setValue: (value: boolean) => void;
+  message?: string;
+}
+
+export default function CheckboxInputWithLabel({
+  id,
+  label,
+  checked = false,
+  setValue,
+}: Props) {
+  const handleChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const { checked } = event.currentTarget;
+    setValue(checked);
+  };
+
+  return (
+    <div>
+      <Label id={id} label={label} />
+      <CheckboxInput id={id} checked={checked} onChange={handleChange} />
+    </div>
+  );
+}

--- a/frontend/src/components/molecule/FileInputWithImage.tsx
+++ b/frontend/src/components/molecule/FileInputWithImage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useRef } from 'react';
 import Button from 'components/atoms/Button';
 import styles from 'assets/styles/FileInputWithImage.module.css';
 
@@ -34,6 +34,9 @@ export default function FileInputWithImage({
     e: React.MouseEvent<HTMLElement, MouseEvent>
   ) => {
     URL.revokeObjectURL(imagePreviewUrl);
+    if (fileInput.current) {
+      fileInput.current.value = '';
+    }
     onClickRemove();
     setImagePreviewUrl('');
   };

--- a/frontend/src/components/molecule/TextInputWithMessage.tsx
+++ b/frontend/src/components/molecule/TextInputWithMessage.tsx
@@ -5,7 +5,7 @@ import Message from 'components/atoms/Message';
 
 interface Props {
   id: string;
-  label: string;
+  label?: string;
   value: string;
   placeholder?: string;
   setValue: (value: string) => void;
@@ -44,7 +44,7 @@ export default function TextInputWithMessage({
 
   return (
     <>
-      <Label id={id} label={label} />
+      {label && <Label id={id} label={label} />}
       <TextInput
         id={id}
         value={value}

--- a/frontend/src/components/organisms/OnBoarding/MultiSteps.tsx
+++ b/frontend/src/components/organisms/OnBoarding/MultiSteps.tsx
@@ -1,0 +1,63 @@
+import Button from 'components/atoms/Button';
+import { useState } from 'react';
+import Message from 'components/atoms/Message';
+import { FormData } from 'components/organisms/OnBoarding';
+
+type FunctionORNull = (() => any) | null;
+
+interface Props {
+  formData: FormData;
+  stepComponents: React.ReactElement[];
+  resultComponent: React.ReactElement;
+  validators: FunctionORNull[];
+  messages: string[];
+}
+
+export default function MultiSteps({
+  formData,
+  stepComponents,
+  resultComponent,
+  validators,
+  messages,
+}: Props) {
+  const [stepIndex, setStepIndex] = useState<number>(0);
+  const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
+  const [isValid, setIsValid] = useState<boolean>(true);
+  const isLastStep = stepIndex === stepComponents.length - 1;
+
+  const handleClickPrevStep = () => {
+    if (stepIndex === 0) return;
+    setStepIndex((prevState) => prevState - 1);
+    setIsValid(true);
+  };
+
+  const handleClickNextStep = () => {
+    if (isLastStep) {
+      setIsSubmitted(true);
+      return;
+    }
+    if (!validators[stepIndex]?.()) {
+      setIsValid(false);
+      return;
+    }
+    setStepIndex((prevState) => prevState + 1);
+    setIsValid(true);
+  };
+
+  if (isSubmitted) {
+    return <>{resultComponent}</>;
+  }
+
+  return (
+    <>
+      <Button type="button" onClick={handleClickPrevStep}>
+        &lt;
+      </Button>
+      <form>{stepComponents[stepIndex]}</form>
+      <Message isShow={!isValid} message={messages[stepIndex]} />
+      <Button type="button" onClick={handleClickNextStep}>
+        {isLastStep ? '완료' : '다음'}
+      </Button>
+    </>
+  );
+}

--- a/frontend/src/components/organisms/OnBoarding/StepAgreements.tsx
+++ b/frontend/src/components/organisms/OnBoarding/StepAgreements.tsx
@@ -1,0 +1,91 @@
+import CheckboxInputWithLabel from 'components/molecule/CheckboxInputWithLabel';
+import { FormData } from 'components/organisms/OnBoarding';
+
+interface Props {
+  formData: FormData;
+  setFormData: React.Dispatch<React.SetStateAction<FormData>>;
+}
+
+const checkAll = (state: FormData, key: string, value: boolean): FormData => {
+  const newState: FormData = {
+    ...state,
+    [key]: value,
+  };
+  if (key === 'isCheckedAll') {
+    newState.isCheckedAge = value;
+    newState.isCheckedTerms = value;
+    newState.isCheckedPrivacy = value;
+    newState.isCheckedMarketing = value;
+  }
+  if (
+    newState.isCheckedAge &&
+    newState.isCheckedTerms &&
+    newState.isCheckedPrivacy &&
+    newState.isCheckedMarketing
+  ) {
+    newState.isCheckedAll = value;
+  } else if (!value) {
+    newState.isCheckedAll = value;
+  }
+  return newState;
+};
+
+export default function StepAgreements({ formData, setFormData }: Props) {
+  return (
+    <div>
+      <h2>서비스 이용약관에 동의해 주세요.</h2>
+      <div>
+        <CheckboxInputWithLabel
+          id="step-all"
+          label="모두 동의하기"
+          checked={formData.isCheckedAll}
+          setValue={(checked: boolean) => {
+            setFormData((prevState) =>
+              checkAll(prevState, 'isCheckedAll', checked)
+            );
+          }}
+        />
+        <CheckboxInputWithLabel
+          id="step-age"
+          label="(필수) 만 14세 이상입니다."
+          checked={formData.isCheckedAge}
+          setValue={(checked: boolean) => {
+            setFormData((prevState) =>
+              checkAll(prevState, 'isCheckedAge', checked)
+            );
+          }}
+        />
+        <CheckboxInputWithLabel
+          id="step-terms"
+          label="(필수) 서비스 이용약관"
+          checked={formData.isCheckedTerms}
+          setValue={(checked: boolean) => {
+            setFormData((prevState) =>
+              checkAll(prevState, 'isCheckedTerms', checked)
+            );
+          }}
+        />
+        <CheckboxInputWithLabel
+          id="step-privacy"
+          label="(필수) 개인정보처리방침"
+          checked={formData.isCheckedPrivacy}
+          setValue={(checked: boolean) => {
+            setFormData((prevState) =>
+              checkAll(prevState, 'isCheckedPrivacy', checked)
+            );
+          }}
+        />
+        <CheckboxInputWithLabel
+          id="step-marketing"
+          label="(선택) Team Noir 소식 받아보기"
+          checked={formData.isCheckedMarketing}
+          setValue={(checked: boolean) => {
+            setFormData((prevState) =>
+              checkAll(prevState, 'isCheckedMarketing', checked)
+            );
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/organisms/OnBoarding/StepNickname.tsx
+++ b/frontend/src/components/organisms/OnBoarding/StepNickname.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import TextInputWithMessage from 'components/molecule/TextInputWithMessage';
+import { validateNickname } from 'utils/validatorUtils';
+import { FormData } from 'components/organisms/OnBoarding';
+
+interface Props {
+  formData: FormData;
+  setFormData: React.Dispatch<React.SetStateAction<FormData>>;
+}
+
+export default function StepNickname({ formData, setFormData }: Props) {
+  const [isValid, setIsValid] = useState<boolean>(false);
+  return (
+    <div>
+      <h2>닉네임을 입력해 주세요.</h2>
+      <p>2자 이상 16자 이하의 한글, 영문, 숫자 조합</p>
+      <div>
+        <TextInputWithMessage
+          id="step-nickname"
+          value={formData.nickname}
+          setValue={(value) =>
+            setFormData((prevState) => ({
+              ...prevState,
+              nickname: value,
+            }))
+          }
+          isValid={isValid}
+          setIsValid={setIsValid}
+          validate={validateNickname}
+          message="유효하지 않은 닉네임입니다."
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/organisms/OnBoarding/StepProfileImage.tsx
+++ b/frontend/src/components/organisms/OnBoarding/StepProfileImage.tsx
@@ -1,0 +1,41 @@
+import FileInputWithImage from 'components/molecule/FileInputWithImage';
+import { FormData } from 'components/organisms/OnBoarding';
+
+interface Props {
+  setFormData: React.Dispatch<React.SetStateAction<FormData>>;
+}
+
+// TODO: 나중에 default image 파일 경로로 수정
+const defaultImage = 'https://placekitten.com/800/800';
+
+export default function StepProfileImage({ setFormData }: Props) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = e.target;
+    if (!files) return;
+
+    setFormData((prevState) => ({
+      ...prevState,
+      profileImage: files[0],
+    }));
+  };
+
+  const handleClickRemove = () => {
+    setFormData((prevState) => ({
+      ...prevState,
+      profileImage: null,
+    }));
+  };
+
+  return (
+    <div>
+      <h2>프로필 이미지를 설정해 주세요.</h2>
+      <div>
+        <FileInputWithImage
+          imageUrl={defaultImage}
+          onChange={handleChange}
+          onClickRemove={handleClickRemove}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/organisms/OnBoarding/StepWelcome.tsx
+++ b/frontend/src/components/organisms/OnBoarding/StepWelcome.tsx
@@ -1,0 +1,14 @@
+import { Link } from 'react-router-dom';
+
+export default function StepWelcome() {
+  return (
+    <div>
+      <h2>환영합니다.</h2>
+      <p>지금 바로 게임을 시작하거나 친구와 만나보세요.</p>
+      <div>
+        <img src="https://placekitten.com/800/800" alt="welcom image" />
+      </div>
+      <Link to="/">메인으로</Link>
+    </div>
+  );
+}

--- a/frontend/src/components/organisms/OnBoarding/index.tsx
+++ b/frontend/src/components/organisms/OnBoarding/index.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import MultiSteps from 'components/organisms/OnBoarding/MultiSteps';
+import StepAgreements from 'components/organisms/OnBoarding/StepAgreements';
+import StepNickname from 'components/organisms/OnBoarding/StepNickname';
+import StepProfileImage from 'components/organisms/OnBoarding/StepProfileImage';
+import StepWelcome from 'components/organisms/OnBoarding/StepWelcome';
+import { validateAgreements, validateNickname } from 'utils/validatorUtils';
+
+export interface FormData {
+  isCheckedAll: boolean;
+  isCheckedAge: boolean;
+  isCheckedTerms: boolean;
+  isCheckedPrivacy: boolean;
+  isCheckedMarketing: boolean;
+  nickname: string;
+  profileImage: File | null;
+}
+
+export default function OnBoarding() {
+  const [formData, setFormData] = useState<FormData>({
+    isCheckedAll: false,
+    isCheckedAge: false,
+    isCheckedTerms: false,
+    isCheckedPrivacy: false,
+    isCheckedMarketing: false,
+    nickname: '',
+    profileImage: null,
+  });
+
+  return (
+    <>
+      <h1>OnBoarding</h1>
+      <MultiSteps
+        formData={formData}
+        stepComponents={[
+          <StepAgreements
+            key={0}
+            formData={formData}
+            setFormData={setFormData}
+          />,
+          <StepNickname
+            key={1}
+            formData={formData}
+            setFormData={setFormData}
+          />,
+          <StepProfileImage key={2} setFormData={setFormData} />,
+        ]}
+        resultComponent={<StepWelcome />}
+        validators={[
+          () =>
+            validateAgreements([
+              formData.isCheckedAge,
+              formData.isCheckedTerms,
+              formData.isCheckedPrivacy,
+            ]),
+          () => validateNickname(formData.nickname),
+          null,
+        ]}
+        messages={['필수 약관에 동의해주세요.', '닉네임을 입력해주세요.', '']}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/organisms/Setting.tsx
+++ b/frontend/src/components/organisms/Setting.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import TextInputWithMessage from 'components/molecule/TextInputWithMessage';
 import Button from 'components/atoms/Button';
 import FileInputWithImage from 'components/molecule/FileInputWithImage';
+import { validateNickname } from 'utils/validatorUtils';
 
 interface UserForm {
   nickname: string;
@@ -29,12 +30,6 @@ export default function Setting() {
       nickname: '닉네임',
     });
   }, []);
-
-  const validateNickname = (nickname: string) => {
-    // 2자 이상 16자 이하, 영어 또는 숫자 또는 한글
-    const nicknameRegex = /^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,16}$/;
-    return nicknameRegex.test(nickname);
-  };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = e.target;

--- a/frontend/src/pages/OnBoardingPage.tsx
+++ b/frontend/src/pages/OnBoardingPage.tsx
@@ -1,5 +1,10 @@
-import React from 'react';
+import OnBoarding from 'components/organisms/OnBoarding';
 
 export default function OnBoardingPage() {
-  return <div>OnBoardingPage</div>;
+  return (
+    <>
+      <div>OnBoardingPage</div>
+      <OnBoarding />
+    </>
+  );
 }

--- a/frontend/src/tests/OnBoarding.test.tsx
+++ b/frontend/src/tests/OnBoarding.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import OnBoarding from 'components/organisms/OnBoarding';
+
+describe('Component - OnBoarding 렌더링', () => {
+  test('온보딩 페이지를 보여준다', () => {
+    render(<OnBoarding />);
+    screen.findByText('서비스 이용약관에 동의해 주세요.');
+    screen.findByText('모두 동의하기');
+    screen.findByText('다음');
+  });
+});

--- a/frontend/src/utils/validatorUtils.ts
+++ b/frontend/src/utils/validatorUtils.ts
@@ -1,0 +1,10 @@
+export function validateAgreements(checkList: boolean[]) {
+  // check if every isRequied is true
+  return checkList.every((c) => c === true);
+}
+
+export function validateNickname(nickname: string) {
+  // 2자 이상 16자 이하, 영어 또는 숫자 또는 한글
+  const nicknameRegex = /^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,16}$/;
+  return nicknameRegex.test(nickname);
+}


### PR DESCRIPTION
## 작업 내용

- 체크박스 인풋 컴포넌트 구현
- validator 유틸 구현
- 파일 인풋에서 이미지 삭제하기 버튼을 눌렀을 때 파일 인풋이 리셋되지 않던 오류 수정
- 텍스트 인풋의 레이블을 옵셔널로 수정
- 온보딩 페이지 구현
- closes #14 
