### PR TITLE
팔로잉 목록 페이지 구현 API 호출

### DIFF
--- a/frontend/src/api/api.v1.ts
+++ b/frontend/src/api/api.v1.ts
@@ -28,6 +28,7 @@ export interface ProfileType {
   rank: number;
   achievements: [];
   games: [];
+  isFollowing: boolean;
 }
 
 export const getProfile = async (userId: string): Promise<ProfileType> => {

--- a/frontend/src/api/api.v1.ts
+++ b/frontend/src/api/api.v1.ts
@@ -53,3 +53,19 @@ export const deleteMyBlocks = async (userId: number) => {
   }
   return res;
 };
+
+export const getMyFollowing = async () => {
+  const res = await axios.get(`/my/following`);
+  if (res.status !== 200) {
+    throw new Error('Failed to get my following');
+  }
+  return res.data;
+};
+
+export const deleteMyFollowing = async (userId: number) => {
+  const res = await axios.delete(`/my/following/${userId}`);
+  if (res.status !== 204) {
+    throw new Error('Failed to delete my following');
+  }
+  return res;
+};

--- a/frontend/src/components/organisms/Following.tsx
+++ b/frontend/src/components/organisms/Following.tsx
@@ -1,46 +1,20 @@
-import { useEffect, useState } from 'react';
 import { UserType } from 'types/userType';
 import UserList from '../molecule/UserList';
 import styles from 'assets/styles/Following.module.css';
 import Button from 'components/atoms/Button';
 
-const dummyFollowings: UserType[] = [
-  {
-    id: 2,
-    nickname: '닉네임2',
-    status: 'on',
-  },
-  {
-    id: 3,
-    nickname: '닉네임3',
-    status: 'on',
-  },
-  {
-    id: 4,
-    nickname: '닉네임4',
-    status: 'off',
-  },
-  {
-    id: 5,
-    nickname: '닉네임5',
-    status: 'game',
-  },
-];
+interface Props {
+  users: UserType[];
+  onClickUnfollow: (e: React.MouseEvent<HTMLElement>) => void;
+}
 
-export default function Following() {
-  const [followings, setFollowings] = useState<UserType[] | null>(null);
-
-  // TODO: 내 팔로우 목록 API에서 가져오기
-  useEffect(() => {
-    setFollowings(dummyFollowings);
-  }, []);
-
+export default function Following({ users, onClickUnfollow }: Props) {
   return (
     <>
       <h1>Following</h1>
       <UserList
         styles={styles}
-        users={followings}
+        users={users}
         imageSize={52}
         hasStatus={true}
         buttons={[
@@ -50,7 +24,7 @@ export default function Following() {
           <Button key="button1" type="button">
             메시지 보내기
           </Button>,
-          <Button key="button2" type="button">
+          <Button key="button2" type="button" onClick={onClickUnfollow}>
             언팔로우
           </Button>,
         ]}

--- a/frontend/src/components/organisms/Profile.tsx
+++ b/frontend/src/components/organisms/Profile.tsx
@@ -29,7 +29,6 @@ export default function Profile({
         size={320}
       />
       <p data-testid={user.id}>{user.nickname}</p>
-      <Link to="/profile/2">user2</Link>
       {isMyPage && <Link to="/setting">프로필 수정하기</Link>}
       {!isMyPage && (
         <div>

--- a/frontend/src/components/organisms/Profile.tsx
+++ b/frontend/src/components/organisms/Profile.tsx
@@ -7,18 +7,11 @@ import { UserType } from 'types/userType';
 interface Props {
   user: ProfileType;
   myId: string;
-  followings: UserType[] | null;
   onClickUnfollow: (userId: number) => void;
 }
 
-export default function Profile({
-  user,
-  myId,
-  followings,
-  onClickUnfollow,
-}: Props) {
+export default function Profile({ user, myId, onClickUnfollow }: Props) {
   const isMyPage = user.id.toString() === myId;
-  const isFollowing = followings?.some((following) => following.id === user.id);
 
   return (
     <>
@@ -32,12 +25,12 @@ export default function Profile({
       {isMyPage && <Link to="/setting">프로필 수정하기</Link>}
       {!isMyPage && (
         <div>
-          {isFollowing && (
+          {user.isFollowing && (
             <Button type="button" onClick={() => onClickUnfollow(user.id)}>
               언팔로우
             </Button>
           )}
-          {!isFollowing && <Button type="button">팔로우하기</Button>}
+          {!user.isFollowing && <Button type="button">팔로우하기</Button>}
           <Button type="button">차단하기</Button>
         </div>
       )}

--- a/frontend/src/components/organisms/Profile.tsx
+++ b/frontend/src/components/organisms/Profile.tsx
@@ -1,16 +1,24 @@
-import { useState, useEffect } from 'react';
 import Button from 'components/atoms/Button';
 import { Link } from 'react-router-dom';
 import ProfileImage from 'components/atoms/ProfileImage';
 import { API_PREFIX, ProfileType } from 'api/api.v1';
+import { UserType } from 'types/userType';
 
 interface Props {
   user: ProfileType;
   myId: string;
+  followings: UserType[] | null;
+  onClickUnfollow: (userId: number) => void;
 }
 
-export default function Profile({ user, myId }: Props) {
+export default function Profile({
+  user,
+  myId,
+  followings,
+  onClickUnfollow,
+}: Props) {
   const isMyPage = user.id.toString() === myId;
+  const isFollowing = followings?.some((following) => following.id === user.id);
 
   return (
     <>
@@ -21,10 +29,16 @@ export default function Profile({ user, myId }: Props) {
         size={320}
       />
       <p data-testid={user.id}>{user.nickname}</p>
+      <Link to="/profile/2">user2</Link>
       {isMyPage && <Link to="/setting">프로필 수정하기</Link>}
       {!isMyPage && (
         <div>
-          <Button type="button">팔로우하기</Button>
+          {isFollowing && (
+            <Button type="button" onClick={() => onClickUnfollow(user.id)}>
+              언팔로우
+            </Button>
+          )}
+          {!isFollowing && <Button type="button">팔로우하기</Button>}
           <Button type="button">차단하기</Button>
         </div>
       )}

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -21,6 +21,29 @@ const mockBlocks: UserType[] = [
   },
 ];
 
+const mockFollowings: UserType[] = [
+  {
+    id: 1,
+    nickname: 'Mock Following Nickname1',
+    status: 'on',
+  },
+  {
+    id: 2,
+    nickname: 'Mock Following Nickname2',
+    status: 'off',
+  },
+  {
+    id: 3,
+    nickname: 'Mock Following Nickname3',
+    status: 'game',
+  },
+  {
+    id: 4,
+    nickname: 'Mock Following Nickname4',
+    status: 'off',
+  },
+];
+
 export const handlers = [
   rest.get(`${API_PREFIX}/health-check`, (req, res, ctx) => {
     return res(
@@ -54,6 +77,20 @@ export const handlers = [
       return res(ctx.status(404));
     }
     mockBlocks.splice(index, 1);
+    return res(ctx.status(204));
+  }),
+
+  rest.get(`${API_PREFIX}/my/following`, (_, res, ctx) => {
+    return res(ctx.json(mockFollowings));
+  }),
+
+  rest.delete(`${API_PREFIX}/my/following/:userId`, (req, res, ctx) => {
+    const userId = Number(req.params.userId);
+    const index = mockFollowings.findIndex((user) => user.id === userId);
+    if (index === -1) {
+      return res(ctx.status(404));
+    }
+    mockFollowings.splice(index, 1);
     return res(ctx.status(204));
   }),
 ];

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -62,6 +62,9 @@ export const handlers = [
         rank: 0,
         achievements: [],
         games: [],
+        isFollowing: mockFollowings.some(
+          (user) => user.id === parseInt(userId)
+        ),
       })
     );
   }),

--- a/frontend/src/pages/FollowingPage.tsx
+++ b/frontend/src/pages/FollowingPage.tsx
@@ -1,10 +1,42 @@
 import Following from 'components/organisms/Following';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { UserType } from 'types/userType';
+import { AxiosError } from 'axios';
+import { deleteMyFollowing, getMyFollowing } from 'api/api.v1';
 
 export default function FollowingPage() {
+  const getMyFollowingQuery = useQuery<UserType[], AxiosError>({
+    queryKey: ['getMyFollowing'],
+    queryFn: getMyFollowing,
+  });
+
+  const deleteMyFollowingMutation = useMutation(deleteMyFollowing);
+
+  const handleClickUnfollow = (e: React.MouseEvent<HTMLElement>) => {
+    const ancestorElement = e.currentTarget.closest('[data-user-id]');
+    if (!(ancestorElement instanceof HTMLElement)) return;
+    const userId = ancestorElement.dataset.userId;
+
+    const answer = confirm('언팔로우하시겠습니까?');
+    if (!answer) return;
+    deleteMyFollowingMutation.mutate(Number(userId));
+  };
+
   return (
     <>
-      <h1>FollowingPage</h1>
-      <Following />
+      {getMyFollowingQuery.isLoading && <div>Loading...</div>}
+      {getMyFollowingQuery.isError && (
+        <div>{getMyFollowingQuery.error.message}</div>
+      )}
+      {getMyFollowingQuery.isSuccess && (
+        <>
+          <h1>FollowingPage</h1>
+          <Following
+            users={getMyFollowingQuery.data}
+            onClickUnfollow={handleClickUnfollow}
+          />
+        </>
+      )}
     </>
   );
 }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -2,7 +2,6 @@ import Profile from 'components/organisms/Profile';
 import Achievements from 'components/organisms/Achievements';
 import {
   deleteMyFollowing,
-  getMyFollowing,
   getProfile,
   getWhoami,
   ProfileType,
@@ -23,11 +22,6 @@ export default function ProfilePage() {
   const whoamiQuery = useQuery<UserType, AxiosError>({
     queryKey: ['whoami'],
     queryFn: getWhoami,
-  });
-
-  const getMyFollowingQuery = useQuery<UserType[], AxiosError>({
-    queryKey: ['getMyFollowing'],
-    queryFn: getMyFollowing,
   });
 
   const deleteMyFollowingMutation = useMutation(deleteMyFollowing);
@@ -51,7 +45,6 @@ export default function ProfilePage() {
           <Profile
             user={profileQuery.data}
             myId={`${whoamiQuery.data.id}`}
-            followings={getMyFollowingQuery.data || null}
             onClickUnfollow={handleClickUnfollow}
           />
           {/* <Achievements id={profileQuery.data.id} /> */}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,7 +1,13 @@
 import Profile from 'components/organisms/Profile';
 import Achievements from 'components/organisms/Achievements';
-import { getProfile, getWhoami, ProfileType } from 'api/api.v1';
-import { useQuery } from '@tanstack/react-query';
+import {
+  deleteMyFollowing,
+  getMyFollowing,
+  getProfile,
+  getWhoami,
+  ProfileType,
+} from 'api/api.v1';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
 import { AxiosError } from 'axios';
 import { UserType } from 'types/userType';
@@ -19,6 +25,19 @@ export default function ProfilePage() {
     queryFn: getWhoami,
   });
 
+  const getMyFollowingQuery = useQuery<UserType[], AxiosError>({
+    queryKey: ['getMyFollowing'],
+    queryFn: getMyFollowing,
+  });
+
+  const deleteMyFollowingMutation = useMutation(deleteMyFollowing);
+
+  const handleClickUnfollow = (userId: number) => {
+    const answer = confirm('언팔로우하시겠습니까?');
+    if (!answer) return;
+    deleteMyFollowingMutation.mutate(Number(userId));
+  };
+
   return (
     <>
       {(profileQuery.isLoading || whoamiQuery.isLoading) && (
@@ -29,7 +48,12 @@ export default function ProfilePage() {
       {profileQuery.isSuccess && whoamiQuery.isSuccess && (
         <>
           <div>ProfilePage</div>
-          <Profile user={profileQuery.data} myId={`${whoamiQuery.data.id}`} />
+          <Profile
+            user={profileQuery.data}
+            myId={`${whoamiQuery.data.id}`}
+            followings={getMyFollowingQuery.data || null}
+            onClickUnfollow={handleClickUnfollow}
+          />
           {/* <Achievements id={profileQuery.data.id} /> */}
         </>
       )}

--- a/frontend/src/tests/Following.test.tsx
+++ b/frontend/src/tests/Following.test.tsx
@@ -1,12 +1,41 @@
 import { render, screen } from '@testing-library/react';
 import Following from 'components/organisms/Following';
 import { BrowserRouter } from 'react-router-dom';
+import { UserType } from 'types/userType';
+
+const mockFollowings: UserType[] = [
+  {
+    id: 1,
+    nickname: 'Mock Following Nickname1',
+    status: 'on',
+  },
+  {
+    id: 2,
+    nickname: 'Mock Following Nickname2',
+    status: 'off',
+  },
+  {
+    id: 3,
+    nickname: 'Mock Following Nickname3',
+    status: 'game',
+  },
+  {
+    id: 4,
+    nickname: 'Mock Following Nickname4',
+    status: 'off',
+  },
+];
 
 describe('Component - Following 렌더링', () => {
+  const handleClickUnfollow = () => console.log('Unfollowed');
+
   test('팔로잉 목록을 보여준다', () => {
     render(
       <BrowserRouter>
-        <Following />
+        <Following
+          users={mockFollowings}
+          onClickUnfollow={handleClickUnfollow}
+        />
       </BrowserRouter>
     );
     screen.getByText('Following');
@@ -15,12 +44,13 @@ describe('Component - Following 렌더링', () => {
   test('더미 데이터 목록을 보여준다', () => {
     render(
       <BrowserRouter>
-        <Following />
+        <Following
+          users={mockFollowings}
+          onClickUnfollow={handleClickUnfollow}
+        />
       </BrowserRouter>
     );
-    screen.findByText('닉네임2');
-    screen.findByAltText(`닉네임2's profile image`);
-    screen.findByText('닉네임3');
-    screen.findByAltText(`닉네임3's profile image`);
+    screen.findByText('Mock Following Nickname1');
+    screen.findByAltText(`Mock Following Nickname1's profile image`);
   });
 });

--- a/frontend/src/tests/Profile.test.tsx
+++ b/frontend/src/tests/Profile.test.tsx
@@ -1,18 +1,49 @@
 import { render, screen } from '@testing-library/react';
 import { ProfileType } from 'api/api.v1';
 import Profile from 'components/organisms/Profile';
+import { UserType } from 'types/userType';
+
+const profileUser: ProfileType = {
+  id: 1,
+  nickname: `user1's nickname`,
+  rank: 0,
+  achievements: [],
+  games: [],
+};
+
+const mockFollowings: UserType[] = [
+  {
+    id: 1,
+    nickname: 'Mock Following Nickname1',
+    status: 'on',
+  },
+  {
+    id: 2,
+    nickname: 'Mock Following Nickname2',
+    status: 'off',
+  },
+  {
+    id: 3,
+    nickname: 'Mock Following Nickname3',
+    status: 'game',
+  },
+  {
+    id: 4,
+    nickname: 'Mock Following Nickname4',
+    status: 'off',
+  },
+];
 
 describe('Component - Profile 렌더링', () => {
-  const profileUser: ProfileType = {
-    id: 1,
-    nickname: `user1's nickname`,
-    rank: 0,
-    achievements: [],
-    games: [],
-  };
-
   test('닉네임과 프로필 사진을 보여준다', () => {
-    render(<Profile user={profileUser} myId={'2'} />);
+    render(
+      <Profile
+        user={profileUser}
+        myId={'2'}
+        followings={mockFollowings}
+        onClickUnfollow={() => console.log('Unfollowed')}
+      />
+    );
     screen.getByText(`user1's nickname`);
     screen.getByAltText('profile image');
     screen.getByText('팔로우하기');

--- a/frontend/src/tests/Profile.test.tsx
+++ b/frontend/src/tests/Profile.test.tsx
@@ -9,6 +9,7 @@ const profileUser: ProfileType = {
   rank: 0,
   achievements: [],
   games: [],
+  isFollowing: false,
 };
 
 const mockFollowings: UserType[] = [
@@ -40,7 +41,6 @@ describe('Component - Profile 렌더링', () => {
       <Profile
         user={profileUser}
         myId={'2'}
-        followings={mockFollowings}
         onClickUnfollow={() => console.log('Unfollowed')}
       />
     );


### PR DESCRIPTION
## 작업 내용

- 팔로잉 목록 가져오기
- 언팔로우하기
- 프로필 페이지에 언팔로우 버튼 추가
- closes #139 

## 리뷰어에게
- 프로필에서 팔로우 여부를 조회하기 위한 더 좋은 로직이 있을 것 같은데 생각나시면 알려주세요 🤔
👉 프로필 API 응답에서 팔로우 여부를 받아오도록 수정