### PR TITLE
회원의 현재 상태를 확인할 수 있는 프로필 사진 옆 아이콘 API 호출

### DIFF
--- a/frontend/src/api/api.v1.ts
+++ b/frontend/src/api/api.v1.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { UserType } from 'types/userType';
 
 export const API_PREFIX = `/api/v1`;
@@ -97,10 +97,12 @@ export const putMyBlocks = async (userId: number) => {
 };
 
 export const getMyFollowing = async () => {
-  const res = await axios.get(`/my/following`);
-  if (res.status !== 200) {
-    throw new Error('Failed to get my following');
-  }
+  const res = await axios.get(`/my/following`).catch((error) => {
+    if (error.response.status === 404) {
+      throw new AxiosError('팔로잉한 회원이 없습니다', '404');
+    }
+    throw error;
+  });
   return res.data;
 };
 

--- a/frontend/src/components/atoms/ProfileImage.tsx
+++ b/frontend/src/components/atoms/ProfileImage.tsx
@@ -11,7 +11,7 @@ export default function ProfileImage({ userId, alt, size }: Props) {
   return (
     <img
       src={
-        userId
+        userId !== undefined
           ? `${API_PREFIX}/users/${userId}/profile-image`
           : 'https://placekitten.com/800/800'
       }

--- a/frontend/src/components/molecule/MessageList.tsx
+++ b/frontend/src/components/molecule/MessageList.tsx
@@ -19,7 +19,7 @@ export default function MessageList({ messages }: Props) {
           <MessageItem
             key={message.id}
             message={message}
-            isShowProfile={!isMyMessage && isContinuousMessage}
+            isShowProfile={!isMyMessage && !isContinuousMessage}
             className={isMyMessage ? styles.my : styles.other}
           />
         );

--- a/frontend/src/components/molecule/UserItem.tsx
+++ b/frontend/src/components/molecule/UserItem.tsx
@@ -3,7 +3,6 @@ import { UserType } from 'types/userType';
 import { Link } from 'react-router-dom';
 import ProfileImage from 'components/atoms/ProfileImage';
 import userItemStyles from 'assets/styles/UserItem.module.css';
-import { API_PREFIX } from 'api/api.v1';
 
 interface Props {
   styles: { readonly [key: string]: string };
@@ -31,9 +30,9 @@ export default function UserItem({
             alt={`${user.nickname}'s profile image`}
             size={imageSize}
           />
-          {hasStatus && user.status !== 'off' && (
+          {hasStatus && user.status !== 'offline' && (
             <div className={userItemStyles.status}>
-              {user.status === 'on' ? '🟢' : 'Game'}
+              {user.status === 'online' ? '🟢' : 'Game'}
             </div>
           )}
         </div>

--- a/frontend/src/components/organisms/SearchResult/index.tsx
+++ b/frontend/src/components/organisms/SearchResult/index.tsx
@@ -6,17 +6,17 @@ const dummyResultUsers: UserType[] = [
   {
     id: 2,
     nickname: '결과닉네임2',
-    status: 'on',
+    status: 'online',
   },
   {
     id: 3,
     nickname: '결과닉네임3',
-    status: 'on',
+    status: 'online',
   },
   {
     id: 4,
     nickname: '결과닉네임4',
-    status: 'off',
+    status: 'offline',
   },
   {
     id: 5,

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -25,12 +25,12 @@ const mockFollowings: UserType[] = [
   {
     id: 1,
     nickname: 'Mock Following Nickname1',
-    status: 'on',
+    status: 'online',
   },
   {
     id: 2,
     nickname: 'Mock Following Nickname2',
-    status: 'off',
+    status: 'offline',
   },
   {
     id: 3,
@@ -40,7 +40,7 @@ const mockFollowings: UserType[] = [
   {
     id: 4,
     nickname: 'Mock Following Nickname4',
-    status: 'off',
+    status: 'offline',
   },
 ];
 

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -123,10 +123,6 @@ export const handlers = [
     return res(ctx.status(204));
   }),
 
-  rest.get(`${API_PREFIX}/my/following`, (_, res, ctx) => {
-    return res(ctx.json(mockFollowings));
-  }),
-
   rest.delete(`${API_PREFIX}/my/following/:userId`, (req, res, ctx) => {
     const userId = Number(req.params.userId);
     const index = mockFollowings.findIndex((user) => user.id === userId);

--- a/frontend/src/tests/Following.test.tsx
+++ b/frontend/src/tests/Following.test.tsx
@@ -7,12 +7,12 @@ const mockFollowings: UserType[] = [
   {
     id: 1,
     nickname: 'Mock Following Nickname1',
-    status: 'on',
+    status: 'online',
   },
   {
     id: 2,
     nickname: 'Mock Following Nickname2',
-    status: 'off',
+    status: 'offline',
   },
   {
     id: 3,
@@ -22,7 +22,7 @@ const mockFollowings: UserType[] = [
   {
     id: 4,
     nickname: 'Mock Following Nickname4',
-    status: 'off',
+    status: 'offline',
   },
 ];
 

--- a/frontend/src/types/userType.ts
+++ b/frontend/src/types/userType.ts
@@ -1,3 +1,5 @@
+type UserStatus = 'online' | 'offline' | 'game';
+
 export interface UserType {
   id: number;
   nickname?: string;
@@ -6,5 +8,5 @@ export interface UserType {
   createdAt?: string;
   updatedAt?: string;
   deletedAt?: string;
-  status?: 'on' | 'off' | 'game';
+  status?: UserStatus;
 }


### PR DESCRIPTION
## 작업 내용

- closes #140 

## 리뷰어에게
- status를 받아오는 부분이 팔로일 목록밖에 없기 때문에 팔로잉 목록을 조회할 때 status를 받아오도록 구현하였습니다. (API는 이미 수정 요청 완료)
- 아직 현재 상태 확인 API(`/api/v1/users/:userId/status`)를 따로 요청할 일은 없어 보입니다.