### PR TITLE
회원 검색하는 REST API 구현

### DIFF
--- a/backend/src/api/users/dtos/users.dto.ts
+++ b/backend/src/api/users/dtos/users.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsString, IsBoolean } from 'class-validator';
+
+export class UserDto {
+  @ApiProperty()
+  @IsNumber()
+  public id: number;
+
+  @ApiProperty()
+  @IsString()
+  public nickname: string;
+
+  @ApiProperty()
+  @IsNumber()
+  public rank: number;
+
+  @ApiProperty()
+  @IsBoolean()
+  public is_followed_by_myself: boolean;
+
+  @ApiProperty()
+  @IsBoolean()
+  public is_blocked_by_myself: boolean;
+
+  // TODO: Type of achievements and games
+  @ApiProperty()
+  public achievements: any[];
+
+  @ApiProperty()
+  public games: any[];
+}

--- a/backend/src/api/users/users.controller.ts
+++ b/backend/src/api/users/users.controller.ts
@@ -1,5 +1,6 @@
 import {
   Controller,
+  Req,
   Res,
   Get,
   UseGuards,
@@ -9,7 +10,8 @@ import {
 import { ApiTags } from '@nestjs/swagger';
 import { AuthenticatedGuard } from 'src/guards/authenticated.guard';
 import { UsersService } from './users.service';
-import { Response } from 'express';
+import { Request, Response } from 'express';
+import { UserDto } from './dtos/users.dto';
 
 @ApiTags('users')
 @Controller('users')
@@ -18,8 +20,12 @@ export class UsersController {
 
   @Get(':userId')
   @UseGuards(AuthenticatedGuard)
-  async requestProfile(@Param('userId') userId: number, @Res() res: Response) {
-    const user = await this.usersService.getUser(Number(userId));
+  async requestProfile(
+    @Req() req: Request,
+    @Param('userId') userId: number,
+    @Res() res: Response
+  ) {
+    const user: UserDto = await this.usersService.getUser(req, Number(userId));
     const statusCode = user ? HttpStatus.OK : HttpStatus.NOT_FOUND;
     res.status(statusCode).send(user);
   }


### PR DESCRIPTION
## 작업 내용

- closes #20

## 리뷰어에게

#### 회원목록 (+ 검색 쿼리) REST API
- GET `/api/v1/users`
- 응답 body에 `is_followed_by_myself`, `is_blocked_by_myself` 도 추가했습니다
- 닉네임 검색 가능합니다. 닉네임에 검색 키워드가 포함되는 유저를 배열로 반환합니다
- 쿼리 파라미터는 우선은 노션 문서 참고해주세요. swagger에서 잘 뜰지 모르겠네요... #190 에서 정리할 예정

#### Injectable
@PCHANUL 
req.user를 자주 컨트롤러->서비스로 넘겨야 하는거 같아서 Injectable 데코레이터로 인젝션 해줬습니다.
```ts
@Injectable({ scope: Scope.REQUEST })
export class UsersService {
  constructor(
    @Inject(REQUEST) private readonly request: RequestWithUser,
    private prismaService: PrismaService
  ) {}
 ...
```

참고
https://stackoverflow.com/questions/54979729/howto-get-req-user-in-services-in-nest-js
https://docs.nestjs.com/fundamentals/injection-scopes#request-provider
