### PR TITLE
채널 참가자 목록에서 참가자 관리 기능 구현

### DIFF
--- a/frontend/src/components/molecule/ChannelUserItem.tsx
+++ b/frontend/src/components/molecule/ChannelUserItem.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 import ProfileImage from 'components/atoms/ProfileImage';
 import userItemStyles from 'assets/styles/UserItem.module.css';
-import { ChannelUserType, UserTypeType } from 'types/channelUserType';
+import { ChannelUserType, RoleType } from 'types/channelUserType';
 import Button from 'components/atoms/Button';
 
 interface Props {
@@ -17,6 +17,8 @@ export default function ChannelUserItem({
   imageSize,
   myUser,
 }: Props) {
+  const isSelf = myUser?.id === user.id;
+
   return (
     <li className={styles.li} data-user-id={user.id}>
       <Link to={`/profile/${user.id}`}>
@@ -31,23 +33,29 @@ export default function ChannelUserItem({
       <Link to={`/profile/${user.id}`}>
         <span>{user.nickname}</span>
       </Link>
-      {myUser && user.id !== myUser.id && (
-        <div>
-          <Button type="button">게임 초대</Button>
-          {myUser.userType === UserTypeType.owner &&
-            (user.userType === UserTypeType.admin ? (
-              <Button type="button">관리자 해제</Button>
-            ) : (
-              <Button type="button">관리자 임명</Button>
-            ))}
-          {myUser.userType <= UserTypeType.admin && (
-            <>
-              <Button type="button">조용히</Button>
-              <Button type="button">내보내기</Button>
-              <Button type="button">차단하기</Button>
-            </>
+      {!isSelf && (
+        <>
+          {myUser?.role === RoleType.normal ? (
+            <Button type="button">게임 초대</Button>
+          ) : (
+            <div>
+              <Button type="button">게임 초대</Button>
+              {myUser?.role === RoleType.owner &&
+                (user.role === RoleType.admin ? (
+                  <Button type="button">관리자 해제</Button>
+                ) : (
+                  <Button type="button">관리자 임명</Button>
+                ))}
+              {user.role !== RoleType.owner && (
+                <>
+                  <Button type="button">조용히</Button>
+                  <Button type="button">내보내기</Button>
+                  <Button type="button">차단하기</Button>
+                </>
+              )}
+            </div>
           )}
-        </div>
+        </>
       )}
     </li>
   );

--- a/frontend/src/components/molecule/ChannelUserItem.tsx
+++ b/frontend/src/components/molecule/ChannelUserItem.tsx
@@ -34,6 +34,12 @@ export default function ChannelUserItem({
       {myUser && user.id !== myUser.id && (
         <div>
           <Button type="button">게임 초대</Button>
+          {myUser.userType === UserTypeType.owner &&
+            (user.userType === UserTypeType.admin ? (
+              <Button type="button">관리자 해제</Button>
+            ) : (
+              <Button type="button">관리자 임명</Button>
+            ))}
           {myUser.userType <= UserTypeType.admin && (
             <>
               <Button type="button">조용히</Button>
@@ -41,12 +47,6 @@ export default function ChannelUserItem({
               <Button type="button">차단하기</Button>
             </>
           )}
-          {myUser.userType === UserTypeType.owner &&
-            (user.userType === UserTypeType.admin ? (
-              <Button type="button">관리자 해제</Button>
-            ) : (
-              <Button type="button">관리자 임명</Button>
-            ))}
         </div>
       )}
     </li>

--- a/frontend/src/components/molecule/ChannelUserItem.tsx
+++ b/frontend/src/components/molecule/ChannelUserItem.tsx
@@ -1,6 +1,5 @@
 import { Link } from 'react-router-dom';
 import ProfileImage from 'components/atoms/ProfileImage';
-import userItemStyles from 'assets/styles/UserItem.module.css';
 import { ChannelUserType, RoleType } from 'types/channelUserType';
 import Button from 'components/atoms/Button';
 
@@ -22,16 +21,18 @@ export default function ChannelUserItem({
   return (
     <li className={styles.li} data-user-id={user.id}>
       <Link to={`/profile/${user.id}`}>
-        <div className={userItemStyles.container}>
-          <ProfileImage
-            userId={user.id}
-            alt={`${user.nickname}'s profile image`}
-            size={imageSize}
-          />
-        </div>
+        <ProfileImage
+          userId={user.id}
+          alt={`${user.nickname}'s profile image`}
+          size={imageSize}
+        />
       </Link>
       <Link to={`/profile/${user.id}`}>
-        <span>{user.nickname}</span>
+        <span>
+          {user.role === RoleType.owner && `🕶`}
+          {user.role === RoleType.admin && `👓`}
+          {user.nickname}
+        </span>
       </Link>
       {!isSelf && (
         <>

--- a/frontend/src/components/molecule/ChannelUserItem.tsx
+++ b/frontend/src/components/molecule/ChannelUserItem.tsx
@@ -1,0 +1,54 @@
+import { Link } from 'react-router-dom';
+import ProfileImage from 'components/atoms/ProfileImage';
+import userItemStyles from 'assets/styles/UserItem.module.css';
+import { ChannelUserType, UserTypeType } from 'types/channelUserType';
+import Button from 'components/atoms/Button';
+
+interface Props {
+  styles: { readonly [key: string]: string };
+  user: ChannelUserType;
+  imageSize: number;
+  myUser: ChannelUserType | null;
+}
+
+export default function ChannelUserItem({
+  styles,
+  user,
+  imageSize,
+  myUser,
+}: Props) {
+  return (
+    <li className={styles.li} data-user-id={user.id}>
+      <Link to={`/profile/${user.id}`}>
+        <div className={userItemStyles.container}>
+          <ProfileImage
+            userId={user.id}
+            alt={`${user.nickname}'s profile image`}
+            size={imageSize}
+          />
+        </div>
+      </Link>
+      <Link to={`/profile/${user.id}`}>
+        <span>{user.nickname}</span>
+      </Link>
+      {myUser && user.id !== myUser.id && (
+        <div>
+          <Button type="button">게임 초대</Button>
+          {myUser.userType <= UserTypeType.admin && (
+            <>
+              <Button type="button">조용히</Button>
+              <Button type="button">내보내기</Button>
+              <Button type="button">차단하기</Button>
+            </>
+          )}
+          {myUser.userType === UserTypeType.owner &&
+            (user.userType === UserTypeType.admin ? (
+              <Button type="button">관리자 해제</Button>
+            ) : (
+              <Button type="button">관리자 임명</Button>
+            ))}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/frontend/src/components/molecule/ChannelUserList.tsx
+++ b/frontend/src/components/molecule/ChannelUserList.tsx
@@ -1,0 +1,33 @@
+import { ChannelUserType } from 'types/channelUserType';
+import ChannelUserItem from './ChannelUserItem';
+
+interface Props {
+  styles: { readonly [key: string]: string };
+  users: ChannelUserType[] | null;
+  imageSize: number;
+  myUser: ChannelUserType | null;
+}
+
+export default function ChannelUserList({
+  styles,
+  users,
+  imageSize,
+  myUser,
+}: Props) {
+  return (
+    <ul className={styles.ul}>
+      {users &&
+        users.map((user) => {
+          return (
+            <ChannelUserItem
+              key={user.id}
+              styles={styles}
+              user={user}
+              imageSize={imageSize}
+              myUser={myUser}
+            />
+          );
+        })}
+    </ul>
+  );
+}

--- a/frontend/src/components/molecule/MessageList.tsx
+++ b/frontend/src/components/molecule/MessageList.tsx
@@ -19,7 +19,7 @@ export default function MessageList({ messages }: Props) {
           <MessageItem
             key={message.id}
             message={message}
-            isShowProfile={!isMyMessage && isContinuousMessage}
+            isShowProfile={!isMyMessage && !isContinuousMessage}
             className={isMyMessage ? styles.my : styles.other}
           />
         );

--- a/frontend/src/components/molecule/UserList.tsx
+++ b/frontend/src/components/molecule/UserList.tsx
@@ -1,11 +1,10 @@
 import { ReactElement } from 'react';
 import UserItem from 'components/molecule/UserItem';
 import { UserType } from 'types/userType';
-import { DummyChannelUserType } from 'components/organisms/ChannelSetting';
 
 interface Props {
   styles: { readonly [key: string]: string };
-  users: UserType[] | DummyChannelUserType[] | null;
+  users: UserType[] | null;
   imageSize: number;
   buttons?: ReactElement[];
   hasStatus?: boolean;

--- a/frontend/src/components/organisms/ChannelDetail.tsx
+++ b/frontend/src/components/organisms/ChannelDetail.tsx
@@ -46,7 +46,7 @@ const compare = (user1: ChannelUserType, user2: ChannelUserType) => {
   return 0;
 };
 
-export default function ChannelSetting({ channel }: Props) {
+export default function ChannelDetail({ channel }: Props) {
   const [channelUsers, setChannelUsers] = useState<ChannelUserType[] | null>(
     null
   );
@@ -65,7 +65,7 @@ export default function ChannelSetting({ channel }: Props) {
   return (
     <div>
       {myUser?.role === RoleType.owner && (
-        <Button type="button">채팅방 설정</Button>
+        <Button type="button">채널 설정</Button>
       )}
       <h2>참가자</h2>
       <ChannelUserList

--- a/frontend/src/components/organisms/ChannelSetting.tsx
+++ b/frontend/src/components/organisms/ChannelSetting.tsx
@@ -2,7 +2,7 @@ import Button from 'components/atoms/Button';
 import { useEffect, useState } from 'react';
 import { ChannelType } from 'types/channelType';
 import styles from 'assets/styles/Channel.module.css';
-import { ChannelUserType, UserTypeType } from 'types/channelUserType';
+import { ChannelUserType, RoleType } from 'types/channelUserType';
 import ChannelUserList from 'components/molecule/ChannelUserList';
 
 interface Props {
@@ -13,22 +13,22 @@ const dummyChannelUsers: ChannelUserType[] = [
   {
     id: 0,
     nickname: 'sarchoi',
-    userType: UserTypeType.admin,
+    role: RoleType.admin,
   },
   {
     id: 1,
     nickname: 'heehkim',
-    userType: UserTypeType.owner,
+    role: RoleType.owner,
   },
   {
     id: 2,
     nickname: 'cpak',
-    userType: UserTypeType.normal,
+    role: RoleType.normal,
   },
   {
     id: 3,
     nickname: 'hello',
-    userType: UserTypeType.admin,
+    role: RoleType.admin,
   },
 ];
 
@@ -37,8 +37,8 @@ const myUserId = 1;
 // 내가 가장 위, 다음으로 owner, admin, normal 순, 각 userType끼리는 nickname 순
 const compare = (user1: ChannelUserType, user2: ChannelUserType) => {
   if (user1.id === myUserId) return -1;
-  if (user1.userType !== user2.userType) {
-    return user1.userType - user2.userType;
+  if (user1.role !== user2.role) {
+    return user1.role - user2.role;
   }
   if (user1.nickname && user2.nickname) {
     return user1.nickname.localeCompare(user2.nickname);
@@ -64,7 +64,7 @@ export default function ChannelSetting({ channel }: Props) {
 
   return (
     <div>
-      {myUser?.userType === UserTypeType.owner && (
+      {myUser?.role === RoleType.owner && (
         <Button type="button">채팅방 설정</Button>
       )}
       <h2>참가자</h2>

--- a/frontend/src/components/organisms/ChannelSetting.tsx
+++ b/frontend/src/components/organisms/ChannelSetting.tsx
@@ -1,76 +1,56 @@
 import Button from 'components/atoms/Button';
-import UserList from 'components/molecule/UserList';
-import { ReactElement, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ChannelType } from 'types/channelType';
 import styles from 'assets/styles/Channel.module.css';
+import { ChannelUserType, UserTypeType } from 'types/channelUserType';
+import ChannelUserList from 'components/molecule/ChannelUserList';
 
 interface Props {
   channel: ChannelType;
 }
 
-const dummyUserType = {
-  owner: 0,
-  admin: 1,
-  normal: 2,
-};
-
-export interface DummyChannelUserType {
-  id: number;
-  nickname: string;
-  profileImageUrl: string;
-  userType: number;
-}
-
-const dummyChannelUsers: DummyChannelUserType[] = [
+const dummyChannelUsers: ChannelUserType[] = [
   {
     id: 0,
     nickname: 'sarchoi',
-    profileImageUrl: 'https://placekitten.com/800/800',
-    userType: dummyUserType.admin,
+    userType: UserTypeType.admin,
   },
   {
     id: 1,
     nickname: 'heehkim',
-    profileImageUrl: 'https://placekitten.com/800/800',
-    userType: dummyUserType.owner,
+    userType: UserTypeType.admin,
   },
   {
     id: 2,
     nickname: 'cpak',
-    profileImageUrl: 'https://placekitten.com/800/800',
-    userType: dummyUserType.normal,
+    userType: UserTypeType.normal,
   },
   {
     id: 3,
     nickname: 'hello',
-    profileImageUrl: 'https://placekitten.com/800/800',
-    userType: dummyUserType.admin,
+    userType: UserTypeType.admin,
   },
 ];
 
 const myUserId = 1;
 
 // 내가 가장 위, 다음으로 owner, admin, normal 순, 각 userType끼리는 nickname 순
-const compare = (user1: DummyChannelUserType, user2: DummyChannelUserType) => {
+const compare = (user1: ChannelUserType, user2: ChannelUserType) => {
   if (user1.id === myUserId) return -1;
   if (user1.userType !== user2.userType) {
     return user1.userType - user2.userType;
   }
-  return user1.nickname.localeCompare(user2.nickname);
+  if (user1.nickname && user2.nickname) {
+    return user1.nickname.localeCompare(user2.nickname);
+  }
+  return 0;
 };
 
 export default function ChannelSetting({ channel }: Props) {
-  const [channelUsers, setChannelUsers] = useState<
-    DummyChannelUserType[] | null
-  >(null);
-  const [currentUser, setCurrentUser] = useState<DummyChannelUserType | null>(
+  const [channelUsers, setChannelUsers] = useState<ChannelUserType[] | null>(
     null
   );
-  const [buttons, setButtons] = useState<ReactElement[]>([
-    <Button key="button0" type="button">
-      게임 초대
-    </Button>,
-  ]);
+  const [myUser, setMyUser] = useState<ChannelUserType | null>(null);
 
   useEffect(() => {
     // TODO: 채널 유저 정보를 가져오는 API 호출
@@ -79,40 +59,20 @@ export default function ChannelSetting({ channel }: Props) {
 
   useEffect(() => {
     const user = channelUsers?.find((user) => user.id === myUserId);
-    user && setCurrentUser(user);
+    user && setMyUser(user);
   }, [channelUsers]);
-
-  useEffect(() => {
-    if (currentUser && currentUser.userType >= dummyUserType.admin) {
-      setButtons([
-        <Button key="button0" type="button">
-          게임 초대
-        </Button>,
-        <Button key="button1" type="button">
-          내보내기
-        </Button>,
-        <Button key="button2" type="button">
-          차단하기
-        </Button>,
-        <Button key="button3" type="button">
-          조용히
-        </Button>,
-      ]);
-    }
-  }, [currentUser]);
 
   return (
     <div>
-      {currentUser?.userType === dummyUserType.owner && (
+      {myUser?.userType === UserTypeType.owner && (
         <Button type="button">채팅방 설정</Button>
       )}
       <h2>참가자</h2>
-      <UserList
+      <ChannelUserList
         styles={styles}
         users={channelUsers}
         imageSize={52}
-        buttons={buttons}
-        myUserId={myUserId}
+        myUser={myUser}
       />
     </div>
   );

--- a/frontend/src/components/organisms/ChannelSetting.tsx
+++ b/frontend/src/components/organisms/ChannelSetting.tsx
@@ -18,7 +18,7 @@ const dummyChannelUsers: ChannelUserType[] = [
   {
     id: 1,
     nickname: 'heehkim',
-    userType: UserTypeType.admin,
+    userType: UserTypeType.owner,
   },
   {
     id: 2,

--- a/frontend/src/pages/ChannelPage.tsx
+++ b/frontend/src/pages/ChannelPage.tsx
@@ -1,7 +1,7 @@
 import Button from 'components/atoms/Button';
 import HeaderWithBackButton from 'components/molecule/HeaderWithBackButton';
 import Channel from 'components/organisms/Channel';
-import ChannelSetting from 'components/organisms/ChannelSetting';
+import ChannelDetail from 'components/organisms/ChannelDetail';
 import AppTemplate from 'components/templates/AppTemplate';
 import { useState } from 'react';
 import { LoaderFunctionArgs, useLoaderData } from 'react-router-dom';
@@ -51,7 +51,7 @@ export default function ChannelPage() {
       }
     >
       <Channel channel={channel} />
-      {isShowSetting && <ChannelSetting channel={channel} />}
+      {isShowSetting && <ChannelDetail channel={channel} />}
     </AppTemplate>
   );
 }

--- a/frontend/src/tests/ChannelDetail.test.tsx
+++ b/frontend/src/tests/ChannelDetail.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from '@testing-library/react';
-import ChannelSetting from 'components/organisms/ChannelSetting';
+import ChannelDetail from 'components/organisms/ChannelDetail';
 import { BrowserRouter } from 'react-router-dom';
 import { ChannelType } from 'types/channelType';
 
-describe('Component - ChannelSetting 렌더링', () => {
+describe('Component - ChannelDetail 렌더링', () => {
   const channel: ChannelType = {
     id: '0',
     title: '게임 할 사람',
@@ -13,7 +13,7 @@ describe('Component - ChannelSetting 렌더링', () => {
   test('채널을 보여준다', () => {
     render(
       <BrowserRouter>
-        <ChannelSetting channel={channel} />
+        <ChannelDetail channel={channel} />
       </BrowserRouter>
     );
     screen.getByText('참가자');

--- a/frontend/src/types/channelUserType.tsx
+++ b/frontend/src/types/channelUserType.tsx
@@ -1,0 +1,11 @@
+import { UserType } from './userType';
+
+export const UserTypeType = {
+  owner: 0,
+  admin: 1,
+  normal: 4,
+};
+
+export interface ChannelUserType extends UserType {
+  userType: number;
+}

--- a/frontend/src/types/channelUserType.tsx
+++ b/frontend/src/types/channelUserType.tsx
@@ -1,11 +1,11 @@
 import { UserType } from './userType';
 
-export const UserTypeType = {
+export const RoleType = {
   owner: 0,
   admin: 1,
   normal: 4,
 };
 
 export interface ChannelUserType extends UserType {
-  userType: number;
+  role: number;
 }


### PR DESCRIPTION
## 작업 내용
<img width="520" alt="image" src="https://user-images.githubusercontent.com/72433681/227922482-b1dfd6fe-3e96-4503-96fe-26e27ccd7c17.png">

- closes #68 

## 리뷰어에게
- 채널 참가자 버튼을 관리하는 로직이 복잡해지면서 UserItem, UserList를 재사용하지 않고 새로운 컴포넌트로 분리하였습니다.