### PR TITLE
메인 페이지가 아닌 곳에서 JWT가 만료된 이후 렌더링 시 로그인 페이지로 가지 못하는 문제 

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,7 +27,7 @@ import ChannelLobbyPage from 'pages/ChannelLobbyPage';
 import ChannelBrowsePage from 'pages/ChannelBrowsePage';
 import ChannelNewPage from 'pages/ChannelNewPage';
 import ChannelPage from 'pages/ChannelPage';
-import { getInitialWhoami, getHealthCheck } from 'api/api.v1';
+import { getHealthCheck, getWhoami } from 'api/api.v1';
 
 export const routes = (isLoggedin: boolean, isOnboarded: boolean) => [
   {
@@ -157,8 +157,8 @@ function Init() {
 
   // TODO: error handling
   const { data, isSuccess } = useQuery({
-    queryKey: ['initial-whoami'],
-    queryFn: getInitialWhoami,
+    queryKey: ['whoami'],
+    queryFn: getWhoami,
   });
 
   const mockApi = useQuery({

--- a/frontend/src/api/api.v1.ts
+++ b/frontend/src/api/api.v1.ts
@@ -39,16 +39,12 @@ export const postLogout = async () => {
 
 /** User */
 
-export const getInitialWhoami = async (): Promise<UserType> => {
-  const res = await axios.get(`/my/whoami`);
-  if (res.status !== 200) {
-    throw new Error('Failed to get whoami');
-  }
-  return res.data;
-};
-
 export const getWhoami = async (): Promise<UserType> => {
-  const res = await axiosWithInterceptors.get(`/my/whoami`);
+  let whoamiAxios = axiosWithInterceptors;
+  if (window.document.referrer === `${window.location.origin}/login`) {
+    whoamiAxios = axios;
+  }
+  const res = await whoamiAxios.get(`/my/whoami`);
   if (res.status !== 200) {
     throw new Error(res.statusText);
   }


### PR DESCRIPTION
## 작업 내용

- initialWhoami를 삭제
- whoami에서 요청한 url을 확인 후 login 페이지면 인터셉터 없이 요청하도록 변경
- closes #227 

## 리뷰어에게
