### PR TITLE
채널 생성 페이지 API 호출

### DIFF
--- a/frontend/src/api/api.v1.ts
+++ b/frontend/src/api/api.v1.ts
@@ -180,8 +180,6 @@ export interface ChannelFormType {
   title: string;
   isPrivate?: boolean;
   password?: string;
-  isDm?: boolean;
-  userId?: number;
 }
 
 /** Channel */

--- a/frontend/src/api/api.v1.ts
+++ b/frontend/src/api/api.v1.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { ChannelType } from 'types/channelType';
 import { UserType } from 'types/userType';
 
 export const API_PREFIX = `/api/v1`;
@@ -173,4 +174,23 @@ export const putMyFollowing = async (userId: number) => {
     throw new Error(res.statusText);
   }
   return res;
+};
+
+export interface ChannelFormType {
+  title: string;
+  isPrivate?: boolean;
+  password?: string;
+  isDm?: boolean;
+  userId?: number;
+}
+
+/** Channel */
+export const postNewChannel = async (
+  channelForm: ChannelFormType
+): Promise<ChannelType> => {
+  const res = await axios.post(`/channels`, channelForm);
+  if (res.status !== 200) {
+    throw new Error(res.statusText);
+  }
+  return res.data;
 };

--- a/frontend/src/components/organisms/ChannelNew.tsx
+++ b/frontend/src/components/organisms/ChannelNew.tsx
@@ -1,21 +1,18 @@
+import { useMutation } from '@tanstack/react-query';
+import { ChannelFormType, postNewChannel } from 'api/api.v1';
 import Button from 'components/atoms/Button';
 import CheckboxInputWithLabel from 'components/molecule/CheckboxInputWithLabel';
 import PasswordInputWithMessage from 'components/molecule/PasswordInputWithMessage';
 import TextInputWithMessage from 'components/molecule/TextInputWithMessage';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   validateChannelPassword,
   validateChannelTitle,
 } from 'utils/validatorUtils';
 
-interface ChannelForm {
-  title: string;
-  isPrivate: boolean;
-  password: string;
-}
-
 export default function ChannelNew() {
-  const [formData, setformData] = useState<ChannelForm>({
+  const [formData, setformData] = useState<ChannelFormType>({
     title: '',
     isPrivate: false,
     password: '',
@@ -25,6 +22,9 @@ export default function ChannelNew() {
     password: true,
   });
   const [hasPassword, setHasPassword] = useState(false);
+  const navigate = useNavigate();
+
+  const postNewChannelMutation = useMutation(postNewChannel);
 
   useEffect(() => {
     if (!hasPassword || formData.isPrivate) {
@@ -33,12 +33,22 @@ export default function ChannelNew() {
     }
   }, [hasPassword, formData.isPrivate]);
 
-  const handleSubmit = (e: React.SyntheticEvent) => {
+  useEffect(() => {
+    if (postNewChannelMutation.isError) {
+      alert(`다시 시도해 주세요.`);
+    }
+    if (!postNewChannelMutation.isSuccess) return;
+    const { id } = postNewChannelMutation.data;
+    navigate(`/channel/${id}`);
+  }, [postNewChannelMutation]);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!isValidated.title || !isValidated.password) return;
-    console.log(formData);
-    // TODO: 서버로 데이터 전송
-    // TODO: 생성된 채널로 리다이렉트
+    if (!isValidated.title || !isValidated.password) {
+      alert('입력값을 확인해주세요.');
+      return;
+    }
+    postNewChannelMutation.mutate(formData);
   };
 
   return (
@@ -98,7 +108,7 @@ export default function ChannelNew() {
           {hasPassword && (
             <PasswordInputWithMessage
               id="password"
-              value={formData.password}
+              value={formData.password || ''}
               setValue={(value) =>
                 setformData((prevState) => ({
                   ...prevState,

--- a/frontend/src/components/organisms/ChannelNew.tsx
+++ b/frontend/src/components/organisms/ChannelNew.tsx
@@ -33,22 +33,21 @@ export default function ChannelNew() {
     }
   }, [hasPassword, formData.isPrivate]);
 
-  useEffect(() => {
-    if (postNewChannelMutation.isError) {
-      alert(`다시 시도해 주세요.`);
-    }
-    if (!postNewChannelMutation.isSuccess) return;
-    const { id } = postNewChannelMutation.data;
-    navigate(`/channel/${id}`);
-  }, [postNewChannelMutation]);
-
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!isValidated.title || !isValidated.password) {
       alert('입력값을 확인해주세요.');
       return;
     }
-    postNewChannelMutation.mutate(formData);
+    postNewChannelMutation.mutate(formData, {
+      onError: () => {
+        alert(`다시 시도해 주세요.`);
+      },
+      onSuccess: (data) => {
+        const { id } = data;
+        navigate(`/channel/${id}`);
+      },
+    });
   };
 
   return (

--- a/frontend/src/contexts/socket.ts
+++ b/frontend/src/contexts/socket.ts
@@ -1,7 +1,7 @@
-import * as io from 'socket.io-client';
+import { io } from 'socket.io-client';
 import React from 'react';
 
-export const socket = io.connect('localhost:8080', {
+export const socket = io('localhost:8080', {
   withCredentials: true,
 });
 


### PR DESCRIPTION
## 작업 내용

- closes #235 

## 리뷰어에게
- query나 mutation에 onError, onSuccess 콜백을 전달해서 성공, 오류 시 동작을 바로 정의할 수가 있었답니다...
괜히 복잡하게 useEffect 하고 있었음 😶‍🌫️