### PR TITLE
소켓 message로 보내는 data 객체 수정

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -23,6 +23,7 @@ CLIENT_APP_URL="http://localhost:8080"
 
 ### jwt
 JWT_SECRET="jwt_secret"
+TEST_JWT=""
 
 ## frontend
 REACT_APP_API_URL="http://localhost:8080"

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -2,3 +2,4 @@ prisma/*
 !prisma/schema.prisma
 
 upload
+*.spec.ts

--- a/backend/src/api/channels/channels.controller.spec.ts
+++ b/backend/src/api/channels/channels.controller.spec.ts
@@ -50,7 +50,7 @@ describe('Chat connection', () => {
 
 		socket = io(getSocketDsn(), {
 			extraHeaders: {
-				"cookie": "Authorization=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwibmlja25hbWUiOiJjcGFrIiwiaWF0IjoxNjgwMjQzMTQ0LCJleHAiOjE2ODAyNDY3NDR9.L3liN0o6rRVoVvDVtjX1P8ELCQ3eh5P94FnaoJjVg98"
+				"cookie": `Authorization=${process.env.TEST_JWT}`
 			}
 		});
     });
@@ -80,7 +80,7 @@ describe('Chat connection', () => {
 		socket.off('message', socket.listeners('message')[0]);
         socket.on('message', (data) => {
 			expect(data.channelId).toBe(channel.id);
-			expect(data.sender.id).toBe(user.id);
+			expect(data.senderId).toBe(user.id);
 			expect(data.text).toBe("hello");
             done();
         });

--- a/backend/src/api/channels/channels.controller.spec.ts
+++ b/backend/src/api/channels/channels.controller.spec.ts
@@ -24,7 +24,7 @@ const user: ChannelUser = {
 const publicChannelData: CreateChannelDto = {
 	title: 'public',
 	isPrivate: false,
-	password: undefined,
+	password: null,
 };
 
 describe('Chat connection', () => {

--- a/backend/src/api/channels/channels.service.spec.ts
+++ b/backend/src/api/channels/channels.service.spec.ts
@@ -40,7 +40,7 @@ const user3: ChannelUser = {
 const publicChannelData: CreateChannelDto = {
   title: 'public',
   isPrivate: false,
-  password: undefined,
+  password: null,
 };
 
 const protectedChannelData: CreateChannelDto = {
@@ -52,7 +52,7 @@ const protectedChannelData: CreateChannelDto = {
 const privateChannelData: CreateChannelDto = {
   title: 'private',
   isPrivate: true,
-  password: undefined,
+  password: null,
 };
 
 describe('Channel list', () => {

--- a/backend/src/api/channels/channels.service.ts
+++ b/backend/src/api/channels/channels.service.ts
@@ -127,7 +127,7 @@ export class ChannelsService {
 
     const newMessage: Message = {
       id: this.messageMap.size,
-      senderId: undefined,
+      senderId: null,
       channelId: channel.id,
       isLog: true,
       text: message,
@@ -226,7 +226,7 @@ export class ChannelsService {
         const tarMessage = {
           id: message.id,
           senderId: message.senderId,
-          senderNickname: undefined,
+          senderNickname: null,
           isLog: message.isLog,
           text: message.text,
           createdAt: message.createdAt,
@@ -247,13 +247,13 @@ export class ChannelsService {
     const newChannelId: number = this.channelMap.size;
     const newChannel: Channel = {
       id: newChannelId,
-      title: data.title ? data.title : undefined,
+      title: data.title ? data.title : null,
       isDm: data.isDm ? true : false,
       isPrivate: data.isPrivate ? true : false,
       createdAt: new Date(),
-      password: data.password ? data.password : undefined,
+      password: data.password ? data.password : null,
 
-      owner: undefined,
+      owner: null,
       users: new Set<number>(),
       admin: new Set<number>(),
       muted: new Set<number>(),
@@ -411,7 +411,7 @@ export class ChannelsService {
         isProtected: !channel.isPrivate && channel.password ? true : false,
         isPrivate: channel.isPrivate,
         isDm: channel.isDm,
-        dmUserId: undefined,
+        dmUserId: null,
         userCount: channel.users.size,
         isJoined: channel.users.has(userId),
         createdAt: channel.createdAt,
@@ -505,7 +505,7 @@ export class ChannelsService {
     }
 
     channel.title = data.title;
-    channel.password = data.password ? data.password : undefined;
+    channel.password = data.password ? data.password : null;
     return;
   }
 

--- a/backend/src/api/channels/channels.service.ts
+++ b/backend/src/api/channels/channels.service.ts
@@ -127,7 +127,7 @@ export class ChannelsService {
 
     const newMessage: Message = {
       id: this.messageMap.size,
-      senderId: 0,
+      senderId: undefined,
       channelId: channel.id,
       isLog: true,
       text: message,
@@ -137,8 +137,13 @@ export class ChannelsService {
 
     // socket message
     this.server.to(String(channelId)).emit('message', {
-      channelId: channelId,
-      text: message,
+      id: newMessage.id,
+      channelId: newMessage.channelId,
+      senderId: undefined,
+      senderNickname: undefined,
+      isLog: newMessage.isLog,
+      text: newMessage.text,
+      createdAt: newMessage.createdAt,
     });
     return newMessage;
   }
@@ -185,11 +190,11 @@ export class ChannelsService {
 
     // socket message
     this.server.to(String(channelId)).emit('message', {
-      channelId: channelId,
-      sender: {
-        id: user.id,
-        nickname: user.name,
-      },
+      id: newMessage.id,
+      channelId: newMessage.channelId,
+      senderId: user.id,
+      senderNickname: user.name,
+      isLog: newMessage.isLog,
       text: newMessage.text,
       createdAt: newMessage.createdAt,
     });
@@ -221,22 +226,20 @@ export class ChannelsService {
     const data = [];
     [...this.messageMap.values()].forEach((message) => {
       if (message.channelId == channelId) {
-        
-        let senderNickname;
-        if (message.senderId == 0) {
-          senderNickname = 'notice';
-        } else {
-          senderNickname = this.getUser(message.senderId).name;
-        }
-
-        data.push({
+        const tarMessage = {
           id: message.id,
           senderId: message.senderId,
-          senderNickname: senderNickname,
+          senderNickname: undefined,
           isLog: message.isLog,
           text: message.text,
           createdAt: message.createdAt,
-        });
+        }
+        
+        if (message.senderId) {
+          tarMessage.senderNickname = this.getUser(message.senderId).name;
+        }
+
+        data.push(tarMessage);
       }
     });
 

--- a/backend/src/api/channels/channels.service.ts
+++ b/backend/src/api/channels/channels.service.ts
@@ -136,12 +136,9 @@ export class ChannelsService {
     this.messageMap.set(newMessage.id, newMessage);
 
     // socket message
-    this.server.to(String(channelId)).emit('message', {
+    this.server.to(String(channelId)).emit('notice', {
       id: newMessage.id,
       channelId: newMessage.channelId,
-      senderId: undefined,
-      senderNickname: undefined,
-      isLog: newMessage.isLog,
       text: newMessage.text,
       createdAt: newMessage.createdAt,
     });


### PR DESCRIPTION
## 작업 내용

- 'message'의 data 형식을 통일
```js
{
	"id": number,
	"channelId": number,
	"senderId": number,
	"senderNickname": string,
	"text": string,
	"createdAt": string
}
```

- 채널 메세지는 'notice'로 data를 수신

## 리뷰어에게
