### PR TITLE
게임 시작 버튼을 눌렀을 때 나오는 게임 대기 상태 구현

### DIFF
--- a/frontend/src/api/api.v1.ts
+++ b/frontend/src/api/api.v1.ts
@@ -334,3 +334,13 @@ export const leaveChannel = async (channelId: number) => {
   }
   return res;
 };
+
+/** Game */
+
+export const waitGame = async (isLadder: boolean) => {
+  const res = await axiosWithInterceptors.post(`/games/queue`, { isLadder });
+  if (res.status !== 204) {
+    throw new Error(res.statusText);
+  }
+  return res;
+};

--- a/frontend/src/api/api.v1.ts
+++ b/frontend/src/api/api.v1.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from 'axios';
+import axios, { AxiosResponse, AxiosError } from 'axios';
 import {
   UserType,
   ChannelType,
@@ -337,9 +337,17 @@ export const leaveChannel = async (channelId: number) => {
 
 /** Game */
 
-export const waitGame = async (isLadder: boolean) => {
+export const waitGame = async (isLadder: boolean): Promise<AxiosResponse> => {
   const res = await axiosWithInterceptors.post(`/games/queue`, { isLadder });
   if (res.status !== 204) {
+    throw new Error(res.statusText);
+  }
+  return res;
+};
+
+export const inviteGame = async (userId: number): Promise<AxiosResponse> => {
+  const res = await axiosWithInterceptors.post(`/games/invite`, { userId });
+  if (res.status !== 201) {
     throw new Error(res.statusText);
   }
   return res;

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -27,7 +27,7 @@
     @apply flex min-h-full items-end justify-center p-4 sm:items-center sm:p-0;
   }
   .modal-panel {
-    @apply relative container mx-auto max-w-xl min-h-screen;
+    @apply relative container mx-auto max-w-xl h-screen;
     @apply mt-24 px-4 pb-6 pt-14 overflow-hidden;
     @apply rounded-2xl shadow-lg;
     @apply bg-gradient-to-b from-[#484649] to-[#433c3f] bg-cover bg-center;

--- a/frontend/src/components/molecule/ChannelUserItem.tsx
+++ b/frontend/src/components/molecule/ChannelUserItem.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { updateChannelUserRole, updateChannelUserStatus } from 'api/api.v1';
 import ProfileImage from 'components/atoms/ProfileImage';
 import Button from 'components/atoms/Button';
+import GameInviteButton from './GameInviteButton';
 import {
   ChannelUserStatusType,
   ChannelUserType,
@@ -88,9 +89,7 @@ export default function ChannelUserItem({
 
         {!isSelf && (
           <div className="inline-flex items-center space-x-2">
-            <Button primary size="small">
-              게임 초대
-            </Button>
+            <GameInviteButton />
 
             {amIOwner && (
               <>

--- a/frontend/src/components/molecule/GameInviteButton.tsx
+++ b/frontend/src/components/molecule/GameInviteButton.tsx
@@ -1,0 +1,61 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { inviteGame } from 'api/api.v1';
+import Button from 'components/atoms/Button';
+import Modal from 'components/templates/Modal';
+import useGame from 'hooks/useGame';
+
+export default function GameInviteButton() {
+  const [isWating, setIsWating, alertCode, setAlertCode] = useGame();
+
+  const inviteGameMutation = useMutation({
+    mutationFn: inviteGame,
+    onSuccess: () => setIsWating(true),
+    onError: (error: AxiosError) => {
+      if (!error.status) return;
+
+      if ([400, 409].includes(error.status)) {
+        setAlertCode('unavailable');
+      } else {
+        alert('다시 시도해 주세요.');
+      }
+    },
+  });
+
+  const handleClickInvite = (e: React.MouseEvent<HTMLElement>) => {
+    const ancestorElement = e.currentTarget.closest('[data-user-id]');
+    if (!(ancestorElement instanceof HTMLElement)) return;
+    const userId = ancestorElement.dataset.userId;
+    console.log('userId', userId);
+    inviteGameMutation.mutate(Number(userId));
+  };
+
+  const cancelWaiting = () => {
+    // TODO: 초대 취소 API 요청
+    setIsWating(false);
+  };
+
+  return (
+    <>
+      <Button primary size="small" onClick={handleClickInvite}>
+        게임 초대
+      </Button>
+      {isWating && (
+        <Modal onClickClose={cancelWaiting} fitContent>
+          <p>초대 수락을 기다리는 중...</p>
+          <Button onClick={cancelWaiting}>취소</Button>
+        </Modal>
+      )}
+      {alertCode && (
+        <Modal onClickClose={() => setAlertCode(null)} fitContent>
+          <p>
+            {alertCode === 'rejected' && '초대가 거절되었습니다.'}
+            {alertCode === 'timeout' &&
+              '60초 동안 응답이 없어 대기를 종료합니다.'}
+            {alertCode == 'unavailable' && '초대할 수 없는 회원입니다.'}
+          </p>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/organisms/Following.tsx
+++ b/frontend/src/components/organisms/Following.tsx
@@ -1,5 +1,6 @@
 import UserList from 'components/molecule/UserList';
 import Button from 'components/atoms/Button';
+import GameInviteButton from 'components/molecule/GameInviteButton';
 import { UserType } from 'types';
 
 interface Props {
@@ -16,9 +17,7 @@ export default function Following({ users, onClickUnfollow }: Props) {
         imageSize={52}
         hasStatus={true}
         buttons={[
-          <Button key="button0" primary size="small">
-            게임 초대
-          </Button>,
+          <GameInviteButton key="button0" />,
           <Button key="button1" primary size="small">
             메시지 보내기
           </Button>,

--- a/frontend/src/components/organisms/GameButtons.tsx
+++ b/frontend/src/components/organisms/GameButtons.tsx
@@ -1,32 +1,47 @@
+import useGame from 'hooks/useGame';
+import Modal from 'components/templates/Modal';
 import Button from 'components/atoms/Button';
 
 export default function GameButtons() {
-  const handleClickStartNormalGame = () => {
-    // TODO: call api to start normal game
-  };
+  const [isWating, setIsWating, isTimeOut, setIsTimeOut, waitGameMutation] =
+    useGame();
 
-  const handleClickStartLadderGame = () => {
-    // TODO: call api to start ladder game
+  const cancelWaiting = () => {
+    // TODO: 취소 API 요청
+    setIsWating(false);
   };
 
   return (
-    <div className="flex flex-col gap-2">
-      <Button
-        type="button"
-        primary
-        fullLength
-        onClick={handleClickStartNormalGame}
-      >
-        일반 게임 시작하기
-      </Button>
-      <Button
-        type="button"
-        secondary
-        fullLength
-        onClick={handleClickStartLadderGame}
-      >
-        승급 게임 시작하기
-      </Button>
-    </div>
+    <>
+      <div className="flex flex-col gap-2">
+        <Button
+          type="button"
+          primary
+          fullLength
+          onClick={() => waitGameMutation.mutate(false)}
+        >
+          일반 게임 시작하기
+        </Button>
+        <Button
+          type="button"
+          secondary
+          fullLength
+          onClick={() => waitGameMutation.mutate(true)}
+        >
+          승급 게임 시작하기
+        </Button>
+      </div>
+      {isWating && (
+        <Modal onClickClose={cancelWaiting}>
+          <p>게임 상대를 기다리는 중...</p>
+          <Button onClick={cancelWaiting}>취소</Button>
+        </Modal>
+      )}
+      {isTimeOut && (
+        <Modal onClickClose={() => setIsTimeOut(false)}>
+          <p>게임 상대를 찾을 수 없습니다.</p>
+        </Modal>
+      )}
+    </>
   );
 }

--- a/frontend/src/components/organisms/GameButtons.tsx
+++ b/frontend/src/components/organisms/GameButtons.tsx
@@ -1,10 +1,16 @@
+import { useMutation } from '@tanstack/react-query';
+import { waitGame } from 'api/api.v1';
 import useGame from 'hooks/useGame';
 import Modal from 'components/templates/Modal';
 import Button from 'components/atoms/Button';
 
 export default function GameButtons() {
-  const [isWating, setIsWating, isTimeOut, setIsTimeOut, waitGameMutation] =
-    useGame();
+  const [isWating, setIsWating, alert, setAlert] = useGame();
+
+  const waitGameMutation = useMutation({
+    mutationFn: waitGame,
+    onSuccess: () => setIsWating(true),
+  });
 
   const cancelWaiting = () => {
     // TODO: 취소 API 요청
@@ -32,13 +38,13 @@ export default function GameButtons() {
         </Button>
       </div>
       {isWating && (
-        <Modal onClickClose={cancelWaiting}>
+        <Modal onClickClose={cancelWaiting} fitContent>
           <p>게임 상대를 기다리는 중...</p>
           <Button onClick={cancelWaiting}>취소</Button>
         </Modal>
       )}
-      {isTimeOut && (
-        <Modal onClickClose={() => setIsTimeOut(false)}>
+      {alert && (
+        <Modal onClickClose={() => setAlert(null)} fitContent>
           <p>게임 상대를 찾을 수 없습니다.</p>
         </Modal>
       )}

--- a/frontend/src/components/templates/Modal.tsx
+++ b/frontend/src/components/templates/Modal.tsx
@@ -5,9 +5,14 @@ import { XMarkIcon } from '@heroicons/react/24/outline';
 interface Props {
   children: React.ReactNode;
   onClickClose: () => void;
+  fitContent?: boolean;
 }
 
-export default function Modal({ children, onClickClose }: Props) {
+export default function Modal({
+  children,
+  onClickClose,
+  fitContent = false,
+}: Props) {
   const closeButtonRef = useRef(null);
 
   return (
@@ -40,7 +45,9 @@ export default function Modal({ children, onClickClose }: Props) {
             leaveFrom="opacity-100 translate-y-0 sm:scale-100"
             leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
           >
-            <Dialog.Panel className="modal-panel">
+            <Dialog.Panel
+              className={`modal-panel ${fitContent && 'h-fit w-fit'}`}
+            >
               <XMarkIcon
                 className="absolute top-4 right-4 block h-6 w-6 text-text-light"
                 aria-hidden="true"

--- a/frontend/src/components/templates/Modal.tsx
+++ b/frontend/src/components/templates/Modal.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useRef } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
+import { classNames } from 'utils';
 
 interface Props {
   children: React.ReactNode;
@@ -46,7 +47,9 @@ export default function Modal({
             leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
           >
             <Dialog.Panel
-              className={`modal-panel ${fitContent && 'h-fit w-fit'}`}
+              className={classNames(
+                `modal-panel ${fitContent && 'h-fit w-fit'}`
+              )}
             >
               <XMarkIcon
                 className="absolute top-4 right-4 block h-6 w-6 text-text-light"

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -10,7 +10,7 @@ type ReturnType = [
 
 export default function useGame(): ReturnType {
   const [isWating, setIsWating] = useState(false);
-  const [alert, setAlert] = useState<string | null>(null);
+  const [alertCode, setAlertCode] = useState<string | null>(null);
   const socket = useContext(SocketContext);
 
   useEffect(() => {
@@ -24,7 +24,7 @@ export default function useGame(): ReturnType {
       if (data.gameId) {
         // TODO: 게임 설정 페이지로 이동
       } else {
-        setAlert(data.text);
+        setAlertCode(data.text);
         setIsWating(false);
       }
     });
@@ -35,5 +35,5 @@ export default function useGame(): ReturnType {
     };
   }, [isWating]);
 
-  return [isWating, setIsWating, alert, setAlert];
+  return [isWating, setIsWating, alertCode, setAlertCode];
 }

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -1,0 +1,48 @@
+import { useContext, useEffect, useState } from 'react';
+import { useMutation, UseMutationResult } from '@tanstack/react-query';
+import { AxiosResponse, AxiosError } from 'axios';
+import { waitGame } from 'api/api.v1';
+import { SocketContext } from 'contexts/socket';
+
+type ReturnType = [
+  boolean,
+  React.Dispatch<React.SetStateAction<boolean>>,
+  boolean,
+  React.Dispatch<React.SetStateAction<boolean>>,
+  UseMutationResult<AxiosResponse, AxiosError, boolean>
+];
+
+export default function useGame(): ReturnType {
+  const [isWating, setIsWating] = useState(false);
+  const [isTimeOut, setIsTimeOut] = useState(false);
+  const socket = useContext(SocketContext);
+
+  const waitGameMutation = useMutation<AxiosResponse, AxiosError, boolean>({
+    mutationFn: waitGame,
+    onSuccess: () => setIsWating(true),
+  });
+
+  useEffect(() => {
+    if (!isWating) return;
+
+    socket.on('ping', () => {
+      socket.emit('pong');
+    });
+
+    socket.on('queue', (data: { gameId?: number }) => {
+      if (data.gameId) {
+        // TODO: 게임 설정 페이지로 이동
+      } else {
+        setIsTimeOut(true);
+        setIsWating(false);
+      }
+    });
+
+    return () => {
+      socket.off('ping');
+      socket.off('queue');
+    };
+  }, [isWating]);
+
+  return [isWating, setIsWating, isTimeOut, setIsTimeOut, waitGameMutation];
+}

--- a/frontend/src/hooks/useGame.ts
+++ b/frontend/src/hooks/useGame.ts
@@ -1,26 +1,17 @@
 import { useContext, useEffect, useState } from 'react';
-import { useMutation, UseMutationResult } from '@tanstack/react-query';
-import { AxiosResponse, AxiosError } from 'axios';
-import { waitGame } from 'api/api.v1';
 import { SocketContext } from 'contexts/socket';
 
 type ReturnType = [
   boolean,
   React.Dispatch<React.SetStateAction<boolean>>,
-  boolean,
-  React.Dispatch<React.SetStateAction<boolean>>,
-  UseMutationResult<AxiosResponse, AxiosError, boolean>
+  string | null,
+  React.Dispatch<React.SetStateAction<string | null>>
 ];
 
 export default function useGame(): ReturnType {
   const [isWating, setIsWating] = useState(false);
-  const [isTimeOut, setIsTimeOut] = useState(false);
+  const [alert, setAlert] = useState<string | null>(null);
   const socket = useContext(SocketContext);
-
-  const waitGameMutation = useMutation<AxiosResponse, AxiosError, boolean>({
-    mutationFn: waitGame,
-    onSuccess: () => setIsWating(true),
-  });
 
   useEffect(() => {
     if (!isWating) return;
@@ -29,11 +20,11 @@ export default function useGame(): ReturnType {
       socket.emit('pong');
     });
 
-    socket.on('queue', (data: { gameId?: number }) => {
+    socket.on('queue', (data: { text: string; gameId?: number }) => {
       if (data.gameId) {
         // TODO: 게임 설정 페이지로 이동
       } else {
-        setIsTimeOut(true);
+        setAlert(data.text);
         setIsWating(false);
       }
     });
@@ -44,5 +35,5 @@ export default function useGame(): ReturnType {
     };
   }, [isWating]);
 
-  return [isWating, setIsWating, isTimeOut, setIsTimeOut, waitGameMutation];
+  return [isWating, setIsWating, alert, setAlert];
 }


### PR DESCRIPTION
## 작업 내용

- 게임 시작하기, 게임 초대 버튼을 눌렀을 때 ping, queue 이벤트 리스닝, 모달 노출
- 게임 초대 API, 게임 대기/초대 취소 API, 게임 설정 페이지 구현이 완료되면 수정 필요
- closes #48

## 리뷰어에게
- 게임 대기 로직을 게임 초대에서도 재사용하기 위해 커스텀 훅으로 구현했습니다.
- 모달 위치가 버튼 컴포넌트에 속하는 게 맞을지 고민입니다. 나중에 portal로 모달을 관리한다고 하면 괜찮을 것 같기도 하고요.
- 코드 보다 보니까 소켓 이벤트 string 리터럴들을 변수로 관리해야 하나 고민..