### PR TITLE
health-check의 응답이 502인 상황에서 빈 화면

### DIFF
--- a/frontend/src/components/organisms/ErrorFallbackWithHeader.tsx
+++ b/frontend/src/components/organisms/ErrorFallbackWithHeader.tsx
@@ -1,23 +1,24 @@
 import { FallbackProps } from 'react-error-boundary';
-import Header from 'components/molecule/Header';
-import Button from 'components/atoms/Button';
+import { SERVICE_NAME } from 'constants/index';
+import ErrorFallback from 'components/organisms/ErrorFallback';
+import ROUTES from 'constants/routes';
 
-export default function ErrorFallback({
+export default function ErrorFallbackWithHeader({
   error,
   resetErrorBoundary,
 }: FallbackProps) {
   return (
     <>
-      <Header />
-      <div className="container mx-auto max-w-xl min-h-screen py-24 px-4">
-        <div className="vh-center flex-col text-center mb-4">
-          <h2>에러가 발생했습니다.</h2>
-          <Button primary fullLength onClick={() => resetErrorBoundary()}>
-            다시 시도
-          </Button>
+      <header className="relative">
+        <div className="container mx-auto max-w-xl fixed top-0 left-0 right-0">
+          <div className="h-14 vh-center px-2">
+            <h1 className="text-xl font-normal text-stone-100">
+              <a href={ROUTES.MAIN}>{SERVICE_NAME}</a>
+            </h1>
+          </div>
         </div>
-        <pre style={{ whiteSpace: 'normal' }}>{error.message}</pre>
-      </div>
+      </header>
+      <ErrorFallback error={error} resetErrorBoundary={resetErrorBoundary} />
     </>
   );
 }


### PR DESCRIPTION
## 작업 내용

- Route 외부에서 사용하는 ErrorFallbackWithHeader에서 Header 컴포넌트를 재사용
 => Header 내부에서 useNavigate를 사용하여 에러 발생
- closes #438 

## 리뷰어에게
