### PR TITLE
스타일링

### DIFF
--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -25,7 +25,7 @@
     @apply flex items-center justify-center;
   }
   .modal-wrapper {
-    @apply relative z-10 text-text-light;
+    @apply relative z-[100] text-text-light;
   }
   .modal-backdrop {
     @apply fixed inset-0 bg-black bg-opacity-50;

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -16,6 +16,11 @@
 @tailwind components;
 
 @layer components {
+  .header {
+    @apply container mx-auto max-w-xl;
+    @apply fixed top-0 left-0 right-0;
+    @apply backdrop-blur-md bg-gray-darker/50 z-50;
+  }
   .vh-center {
     @apply flex items-center justify-center;
   }

--- a/frontend/src/assets/style.css
+++ b/frontend/src/assets/style.css
@@ -78,6 +78,11 @@
   .button.link span {
     @apply underline;
   }
+  .button.text {
+    @apply p-[initial];
+    @apply text-primary hover:text-primary-dark;
+    @apply text-base;
+  }
   .badge {
     @apply items-center mt-1 px-2 py-1 bg-gray-dark rounded-full text-xs text-text-light;
   }

--- a/frontend/src/components/atoms/Button.tsx
+++ b/frontend/src/components/atoms/Button.tsx
@@ -10,6 +10,7 @@ interface Props {
   secondary?: boolean;
   fullLength?: boolean;
   linkStyle?: boolean;
+  textStyle?: boolean;
   size?: 'small' | 'medium' | 'large';
   className?: string;
   disabled?: boolean;
@@ -27,6 +28,7 @@ export default function Button({
   secondary = false,
   fullLength = false,
   linkStyle = false,
+  textStyle = false,
   size = 'medium',
   className,
   disabled = false,
@@ -41,6 +43,7 @@ export default function Button({
         secondary && 'secondary',
         fullLength && 'w-full',
         linkStyle && 'link',
+        textStyle && 'text',
         'button',
         size === 'small' && 'small',
         size === 'medium' && 'medium',

--- a/frontend/src/components/molecule/ChannelUserItem.tsx
+++ b/frontend/src/components/molecule/ChannelUserItem.tsx
@@ -132,7 +132,7 @@ export default function ChannelUserItem({
                   className="text-red"
                 >
                   차단하기
-                </Button>{' '}
+                </Button>
               </>
             )}
           </div>

--- a/frontend/src/components/molecule/GameMatchtable.tsx
+++ b/frontend/src/components/molecule/GameMatchtable.tsx
@@ -56,9 +56,9 @@ function GameItemPlayer({
       )}
     >
       <div
-        className={`flex-1 duotone-image rounded-full max-w-${
+        className={`flex-1 rounded-full max-w-${imageSize / 4} max-h-${
           imageSize / 4
-        } max-h-${imageSize / 4}`}
+        }`}
       >
         <ProfileImage
           userId={player.id}

--- a/frontend/src/components/molecule/GameScoretable.tsx
+++ b/frontend/src/components/molecule/GameScoretable.tsx
@@ -7,6 +7,8 @@ interface Props {
   player2: PlayerType;
   liveScore1?: number;
   liveScore2?: number;
+  myUserId?: number | null;
+  layout?: 'vertical' | 'horizontal';
 }
 
 export default function GameScoretable({
@@ -14,27 +16,42 @@ export default function GameScoretable({
   player2,
   liveScore1,
   liveScore2,
+  myUserId,
+  layout = 'vertical',
 }: Props) {
   return (
     <div className="relative inline-flex items-center gap-2">
-      <GameHistoryItemPlayer player={player1} />
+      <GameHistoryItemPlayer player={player1} layout={layout} />
       <span className="text-4xl text-gray-lighter font-light italic">
-        <span className="text-green">{liveScore1 || player1.score}</span>
+        <span className={myUserId === player1.id ? 'text-green' : ''}>
+          {liveScore1 || player1.score}
+        </span>
         <span> : </span>
-        <span className={classNames('relative')}>
+        <span className={myUserId === player2.id ? 'text-green' : ''}>
           {liveScore2 || player2.score}
         </span>
       </span>
-      <GameHistoryItemPlayer player={player2} />
+      <GameHistoryItemPlayer player={player2} layout={layout} />
     </div>
   );
 }
 
-function GameHistoryItemPlayer({ player }: { player: PlayerType }) {
+function GameHistoryItemPlayer({
+  player,
+  layout = 'vertical',
+}: {
+  player: PlayerType;
+  layout?: 'vertical' | 'horizontal';
+}) {
   const imageSize = 52;
 
   return (
-    <div className="flex-initial p-4 flex flex-col items-center justify-between">
+    <div
+      className={classNames(
+        'flex-initial p-4 flex items-center justify-between',
+        layout === 'vertical' ? 'flex-col' : 'flex-row gap-2'
+      )}
+    >
       <div
         className={`flex-1 rounded-full max-w-${imageSize / 4} max-h-${
           imageSize / 4

--- a/frontend/src/components/molecule/GameScoretable.tsx
+++ b/frontend/src/components/molecule/GameScoretable.tsx
@@ -19,7 +19,8 @@ export default function GameScoretable({
     <div className="relative inline-flex items-center gap-2">
       <GameHistoryItemPlayer player={player1} />
       <span className="text-4xl text-gray-lighter font-light italic">
-        <span className="text-green">{liveScore1 || player1.score}</span> :{' '}
+        <span className="text-green">{liveScore1 || player1.score}</span>
+        <span> : </span>
         <span className={classNames('relative')}>
           {liveScore2 || player2.score}
         </span>

--- a/frontend/src/components/molecule/GameScoretable.tsx
+++ b/frontend/src/components/molecule/GameScoretable.tsx
@@ -8,6 +8,7 @@ interface Props {
   liveScore1?: number;
   liveScore2?: number;
   myUserId?: number | null;
+  amIViewer?: boolean;
   layout?: 'vertical' | 'horizontal';
 }
 
@@ -17,17 +18,30 @@ export default function GameScoretable({
   liveScore1,
   liveScore2,
   myUserId,
+  amIViewer = false,
   layout = 'vertical',
 }: Props) {
   return (
     <div className="relative inline-flex items-center gap-2">
       <GameHistoryItemPlayer player={player1} layout={layout} />
       <span className="text-4xl text-gray-lighter font-light italic">
-        <span className={myUserId === player1.id ? 'text-green' : ''}>
+        <span
+          className={classNames(
+            'mr-1',
+            myUserId === player1.id && 'text-green',
+            amIViewer && !player1.isOwner && 'text-red'
+          )}
+        >
           {liveScore1 || player1.score}
         </span>
-        <span> : </span>
-        <span className={myUserId === player2.id ? 'text-green' : ''}>
+        <span>:</span>
+        <span
+          className={classNames(
+            'ml-1',
+            myUserId === player2.id ? 'text-green' : '',
+            amIViewer && !player2.isOwner && 'text-red'
+          )}
+        >
           {liveScore2 || player2.score}
         </span>
       </span>

--- a/frontend/src/components/molecule/Header.tsx
+++ b/frontend/src/components/molecule/Header.tsx
@@ -25,7 +25,7 @@ export default function Header({
   };
 
   return (
-    <div className="container mx-auto max-w-xl fixed top-0 left-0 right-0 backdrop-blur-md">
+    <div className="header">
       <div className="mx-auto max-w-xl px-2">
         <div className="relative flex h-14 items-center justify-between">
           <div className="absolute inset-y-0 left-0 flex items-center">

--- a/frontend/src/components/molecule/HeaderGnb.tsx
+++ b/frontend/src/components/molecule/HeaderGnb.tsx
@@ -38,10 +38,7 @@ export default function HeaderGnb() {
   });
 
   return (
-    <Disclosure
-      as="nav"
-      className="container mx-auto max-w-xl fixed top-0 left-0 right-0 backdrop-blur-md bg-gray-darker/50 z-50"
-    >
+    <Disclosure as="nav" className="header">
       {({ open }) => (
         <>
           <div className="mx-auto max-w-xl px-2">

--- a/frontend/src/components/molecule/MessageItem.tsx
+++ b/frontend/src/components/molecule/MessageItem.tsx
@@ -1,6 +1,6 @@
 import ProfileImage from 'components/atoms/ProfileImage';
 import { MessageType } from 'types';
-import { formatDate, formatTime } from 'utils';
+import { formatDate, formatTime, classNames } from 'utils';
 
 interface Props {
   message: MessageType;
@@ -22,47 +22,55 @@ export default function MessageItem({
           {`${formatDate(message.createdAt)}`}
         </span>
       )}
-      <div
-        className={`flex mb-4 items-end ${`
-        ${isMyMessage ? 'self-end flex-row-reverse' : 'self-start flex-row'}
-        ${isShowProfile ? 'flex-col' : 'flex-row'}
-        ${message.isLog && 'self-center'}
-      `}`}
-      >
-        {!message.isLog && isShowProfile && message.senderId && (
-          <div className="flex">
-            <ProfileImage
-              userId={message.senderId}
-              nickname={`${message.senderNickname}`}
-              size={52}
-            />
-            <span>{message.senderNickname}</span>
-          </div>
-        )}
-        <li
-          className={`flex
-        ${isMyMessage ? 'flex-row-reverse' : 'flex-row'}`}
-        >
-          <p
-            className={`p-2 rounded ${
-              isMyMessage
-                ? 'bg-green text-text-light'
-                : 'bg-gray text-text-dark'
-            }`}
-          >
+      {message.isLog ? (
+        <div className="flex mb-4 vh-center">
+          <span className="p-2 rounded bg-gray-dark text-text-light text-xs leading-3">
             {message.text}
-          </p>
-          {!message.isLog && (
-            <span
-              className={`mx-2 text-xs leading-3 self-end ${
-                isMyMessage && 'text-right'
-              }`}
-            >
-              {`${formatTime(message.createdAt)}`}
-            </span>
+          </span>
+        </div>
+      ) : (
+        <div className={classNames('flex flex-col mb-2 gap-2')}>
+          {isShowProfile && message.senderId && (
+            <div className="flex flex-row items-end gap-2">
+              <ProfileImage
+                userId={message.senderId}
+                nickname={message.senderNickname || ''}
+                size={40}
+              />
+              <span className="leading-none mb-1">
+                {message.senderNickname}
+              </span>
+            </div>
           )}
-        </li>
-      </div>
+          <div className="flex flex-col gap-2">
+            <li
+              className={classNames(
+                'flex',
+                isMyMessage ? 'flex-row-reverse' : 'flex-row'
+              )}
+            >
+              <p
+                className={classNames(
+                  'p-2 rounded',
+                  isMyMessage
+                    ? 'bg-green text-text-light'
+                    : 'bg-gray text-text-dark'
+                )}
+              >
+                {message.text}
+              </p>
+              <span
+                className={classNames(
+                  'mx-2 text-xs leading-3 self-end',
+                  isMyMessage && 'text-right'
+                )}
+              >
+                {formatTime(message.createdAt)}
+              </span>
+            </li>
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/frontend/src/components/organisms/Channel/index.tsx
+++ b/frontend/src/components/organisms/Channel/index.tsx
@@ -168,13 +168,17 @@ export default function Channel({
     <>
       <div
         id="message-list-wrapper"
-        className="h-[80vh] overflow-y-auto"
+        // NOTE: height: 100vh - upper padding - input bar
+        className="h-[calc(100vh-6rem-82px)] overflow-y-auto"
         ref={scrollRef}
       >
         {messages && <MessageList messages={messages} myUserId={myUserId} />}
       </div>
-      <form onSubmit={handleSubmit} className="inline-flex w-full">
-        <div className="w-10/12 vh-center pr-2">
+      <form
+        onSubmit={handleSubmit}
+        className="container max-w-xl inline-flex absolute bottom-0 pt-2 pb-4 px-4 -mx-4 gap-2"
+      >
+        <div className="w-[85%] vh-center">
           <TextInput
             id="message"
             value={formData.message}
@@ -184,7 +188,7 @@ export default function Channel({
             disabled={formData.disabled}
           />
         </div>
-        <div className="w-2/12 vh-center pl-2">
+        <div className="w-[15%] vh-center">
           <Button type="submit" primary fullLength disabled={formData.disabled}>
             보내기
           </Button>

--- a/frontend/src/components/organisms/ChannelLobby.tsx
+++ b/frontend/src/components/organisms/ChannelLobby.tsx
@@ -22,7 +22,7 @@ export default function ChannelLobby({ channels }: Props) {
         <ChannelButtons />
       </section>
       <section className="section">
-        <h2 className="section-title">입장 중인 채널 목록</h2>
+        <h2 className="section-title">참여 중인 채널 목록</h2>
         {channels.length ? (
           <ChannelList channels={channels} onClick={handleClickChannel} />
         ) : (

--- a/frontend/src/components/organisms/ErrorFallback.tsx
+++ b/frontend/src/components/organisms/ErrorFallback.tsx
@@ -8,7 +8,7 @@ export default function ErrorFallback({
   return (
     <div className="container mx-auto max-w-xl min-h-screen py-24 px-4">
       <div className="vh-center flex-col text-center mb-4">
-        <h2>에러가 발생했습니다.</h2>
+        <h2 className="mb-4">에러가 발생했습니다.</h2>
         <Button primary fullLength onClick={() => resetErrorBoundary()}>
           다시 시도
         </Button>

--- a/frontend/src/components/organisms/ErrorFallbackWithHeader.tsx
+++ b/frontend/src/components/organisms/ErrorFallbackWithHeader.tsx
@@ -10,7 +10,7 @@ export default function ErrorFallbackWithHeader({
   return (
     <>
       <header className="relative">
-        <div className="container mx-auto max-w-xl fixed top-0 left-0 right-0">
+        <div className="header">
           <div className="h-14 vh-center px-2">
             <h1 className="text-xl font-normal text-stone-100">
               <a href={ROUTES.MAIN}>{SERVICE_NAME}</a>

--- a/frontend/src/components/organisms/Game/GameResultModal.tsx
+++ b/frontend/src/components/organisms/Game/GameResultModal.tsx
@@ -21,7 +21,8 @@ export default function GameResultModal({
           <div className="relative inline-flex items-center gap-2 my-12">
             <GameResultModalPlayer player={result.winner} isWinner />
             <span className="pt-8 text-4xl text-gray-lighter font-light italic">
-              <span className="text-green">{result.winner.score}</span> :{' '}
+              <span className="text-green">{result.winner.score}</span>
+              <span> : </span>
               <span className="relative">{result.loser.score}</span>
             </span>
             <GameResultModalPlayer player={result.loser} />

--- a/frontend/src/components/organisms/Game/index.tsx
+++ b/frontend/src/components/organisms/Game/index.tsx
@@ -120,6 +120,7 @@ export default function Game({ game }: Props) {
           liveScore1={otherPlayer ? otherPlayer.score : game.players[0].score}
           liveScore2={myPlayer ? myPlayer.score : game.players[1].score}
           myUserId={myUserId}
+          amIViewer={amIViewer}
           layout="horizontal"
         />
       </div>

--- a/frontend/src/components/organisms/Game/index.tsx
+++ b/frontend/src/components/organisms/Game/index.tsx
@@ -119,6 +119,8 @@ export default function Game({ game }: Props) {
           player2={myPlayer || game.players[1]}
           liveScore1={otherPlayer ? otherPlayer.score : game.players[0].score}
           liveScore2={myPlayer ? myPlayer.score : game.players[1].score}
+          myUserId={myUserId}
+          layout="horizontal"
         />
       </div>
 

--- a/frontend/src/components/organisms/Profile/Achievements.tsx
+++ b/frontend/src/components/organisms/Profile/Achievements.tsx
@@ -55,15 +55,9 @@ function AchievementList({
 function AchievementItem({ achievement }: { achievement: AchievementType }) {
   return (
     <li className="vh-center flex-col mb-4 py-4 px-6 text-center bg-gray-light text-text-dark border-gray-dark border-double border-4 border-r-0 border-l-0">
-      <div>
-        <p className="text-lg mb-2">{achievement.title}</p>
-      </div>
-      <div className="max-w-xs mb-1">
-        <p className="text-sm">{achievement.condition}</p>
-      </div>
-      <div className="max-w-xs">
-        <p className="text-sm italic">{achievement.description}</p>
-      </div>
+      <p className="text-xl mb-2">{achievement.title}</p>
+      <p className="mb-2 italic">{achievement.description}</p>
+      <p className="max-w-xs mb-2 text-sm">{achievement.condition}</p>
     </li>
   );
 }

--- a/frontend/src/components/organisms/Setting2FA.tsx
+++ b/frontend/src/components/organisms/Setting2FA.tsx
@@ -28,9 +28,12 @@ export default function Setting2FA() {
       <h2 className="section-title">Two-Factor Authentication (2FA)</h2>
       <p className="mt-4 mb-8">
         2단계 보안 인증을 설정하고 계정을 더욱 강력하게 보호하세요.{' '}
-        <Button onClick={() => setIsShowInfo(true)} linkStyle>
+        <span
+          onClick={() => setIsShowInfo(true)}
+          className="underline cursor-pointer"
+        >
           더 알아보기
-        </Button>
+        </span>
       </p>
       <div>
         {!isTwoFactor ? (

--- a/frontend/src/components/organisms/Setting2FA.tsx
+++ b/frontend/src/components/organisms/Setting2FA.tsx
@@ -27,10 +27,10 @@ export default function Setting2FA() {
     <>
       <h2 className="section-title">Two-Factor Authentication (2FA)</h2>
       <p className="mt-4 mb-8">
-        2단계 보안 인증을 설정하고 계정을 더욱 강력하게 보호하세요.{' '}
+        2단계 보안 인증을 설정하고 계정을 더욱 강력하게 보호하세요.
         <span
           onClick={() => setIsShowInfo(true)}
-          className="underline cursor-pointer"
+          className="underline cursor-pointer ml-1"
         >
           더 알아보기
         </span>

--- a/frontend/src/components/organisms/Setting2FA.tsx
+++ b/frontend/src/components/organisms/Setting2FA.tsx
@@ -28,12 +28,14 @@ export default function Setting2FA() {
       <h2 className="section-title">Two-Factor Authentication (2FA)</h2>
       <p className="mt-4 mb-8">
         2단계 보안 인증을 설정하고 계정을 더욱 강력하게 보호하세요.
-        <span
+        <Button
           onClick={() => setIsShowInfo(true)}
-          className="underline cursor-pointer ml-1"
+          linkStyle
+          textStyle
+          className="ml-1"
         >
           더 알아보기
-        </span>
+        </Button>
       </p>
       <div>
         {!isTwoFactor ? (

--- a/frontend/src/components/templates/AppTemplate.tsx
+++ b/frontend/src/components/templates/AppTemplate.tsx
@@ -26,7 +26,10 @@ export default function AppTemplate({ header, children }: Props) {
             )}
           >
             <Suspense fallback={<LoadingFallback />}>
-              <main className="container mx-auto max-w-xl min-h-screen py-24 px-4">
+              <main
+                className="container mx-auto max-w-xl
+               px-4 pt-24"
+              >
                 {children}
               </main>
             </Suspense>

--- a/frontend/src/pages/ErrorPage.tsx
+++ b/frontend/src/pages/ErrorPage.tsx
@@ -18,7 +18,7 @@ export default function ErrorPage() {
       <Header />
       <div className="container mx-auto max-w-xl min-h-screen py-24 px-4">
         <div className="vh-center flex-col text-center mb-4">
-          <h2>에러가 발생했습니다.</h2>
+          <h2 className="mb-4">에러가 발생했습니다.</h2>
           <Link to="/" className="button primary w-full" replace={true}>
             메인으로 가기
           </Link>


### PR DESCRIPTION
## 작업 내용

- closes #355
- 자잘한 작업 내용 이슈 참고

## 리뷰어에게

<img width="203" alt="image" src="https://user-images.githubusercontent.com/85778562/235837960-7183da14-4b93-4865-9f5e-8119c47f9a30.png">

프로필 사진에 폭을 비워두고 메시지를 정렬하려면 컴포넌트 단위로 수정이 들어가야 되어서 일단은 위의 캡쳐처럼 flex col로 작업했습니다.

참가자로 게임 페이지에 들어갔을 경우, 게임방 오너가 아닌 사람이 빨간색 패들로 뜨기 때문에 점수도 빨간색으로 표시함.