### PR TITLE
프로필 이미지 사이즈 오류

### DIFF
--- a/backend/src/api/my/my.controller.ts
+++ b/backend/src/api/my/my.controller.ts
@@ -37,7 +37,7 @@ import { AuthenticatedGuard } from '@/guards/authenticated.guard';
 import { SettingDto, CheckSettingDto, FileUploadDto } from './dtos/setting.dto';
 import { MyService } from './my.service';
 import { MyDto, FollowDto, BlockDto } from './dtos/my.dto';
-import { PROFILE_PATH } from '@const';
+import { PROFILE_PATH, PROFILE_IMAGE_MAX_SIZE } from '@const';
 
 @ApiTags('my')
 @Controller('my')
@@ -140,7 +140,7 @@ export class MyController {
       new ParseFilePipe({
         validators: [
           new FileTypeValidator({ fileType: /^image\// }),
-          new MaxFileSizeValidator({ maxSize: 1000 }),
+          new MaxFileSizeValidator({ maxSize: PROFILE_IMAGE_MAX_SIZE }),
         ],
       })
     )

--- a/backend/src/const.ts
+++ b/backend/src/const.ts
@@ -1,5 +1,6 @@
 export const ONESECOND = 1000;
 export const PROFILE_PATH = 'uploads/profile-images/';
+export const PROFILE_IMAGE_MAX_SIZE = 1048576; // 1MB
 
 // Socket API 'notice' event codes
 export const NOTICE_STATUS = {


### PR DESCRIPTION
## 작업 내용

프로필 이미지 사이즈가 너무 작게 설정 되어 있었던 문제

nginx 기본값이 1mb이기 때문에, 우선 1mb로 설정했습니다.