### PR TITLE
메인 페이지에 관전자 순으로 라이브 게임 목록 표시

### DIFF
--- a/frontend/src/api/rest.v1.ts
+++ b/frontend/src/api/rest.v1.ts
@@ -438,9 +438,9 @@ export const getGame = async (gameId: number): Promise<GameType> => {
 export const getGames = async (
   paging: PageParamsType
 ): Promise<ListWithPagingType<GameType>> => {
-  const { cursor, size, order } = paging;
+  const { cursor, size, order, sort } = paging;
   const res = await axiosWithInterceptors.get(`/games`, {
-    params: { cursor, size, order },
+    params: { cursor, size, order, sort },
   });
   if (res.status !== StatusCodes.OK) {
     throw new Error(res.statusText);

--- a/frontend/src/components/organisms/Main.tsx
+++ b/frontend/src/components/organisms/Main.tsx
@@ -12,7 +12,7 @@ import ChannelList from 'components/molecule/ChannelList';
 export default function Main() {
   const { data: games } = useQuery({
     queryKey: [QUERY_KEYS.GAMES, 'main'],
-    queryFn: () => getGames({ size: 3 }),
+    queryFn: () => getGames({ size: 3, sort: 'viewers' }),
   });
 
   const { data: channels } = useQuery({

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,7 +10,7 @@ export type ListWithPagingType<T> = {
 };
 
 export type OrderType = 'asc' | 'desc';
-export type SortType = 'created' | 'users';
+export type SortType = 'created' | 'users' | 'viewers';
 
 export type PageParamsType = {
   cursor?: string | null;


### PR DESCRIPTION
## 작업 내용

- closes #581 

## 리뷰어에게
